### PR TITLE
✅ feat : ErrorCode 추가 후 GlobalExceptionHandler refactor

### DIFF
--- a/src/main/java/com/prgrms/coretime/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorCode.java
@@ -1,0 +1,43 @@
+package com.prgrms.coretime.common;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+  /**
+   * Code 팀원들끼리 정해야하는데 이거 관리해야하나여..?ㅠㅠ 깃모지 될 것 같은데...
+   */
+
+  //Internal Server Error
+  INTERNAL_SERVER_ERROR(500, "code01", "서버에 문제가 생겼습니다."),
+
+  // 400 Client Error
+  METHOD_NOT_ALLOWED(405, "code02", "적절하지 않은 HTTP 메소드입니다."),
+  INVALID_TYPE_VALUE(400, "code03", "요청 값의 타입이 잘못되었습니다."),
+  INVALID_INPUT_VALUE(400, "code04", "적절하지 않은 요청값입니다.");
+
+  private final int status;
+  private final String code;
+  private final String message;
+
+  ErrorCode(int status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  private static final Map<String, ErrorCode> messageMap
+      = Collections.unmodifiableMap(Stream.of(values())
+      .collect(Collectors.toMap(ErrorCode::getMessage, Function.identity())));
+
+  public static ErrorCode fromMessage(String message) {
+    return messageMap.get(message);
+  }
+
+}

--- a/src/main/java/com/prgrms/coretime/common/ErrorResponse.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorResponse.java
@@ -1,14 +1,29 @@
 package com.prgrms.coretime.common;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
-  private String errorCode;
+
+  private int status;
+  private String code;
   private String message;
 
-  public ErrorResponse(String errorCode, String message) {
-    this.errorCode = errorCode;
+  /**
+   * status 넣은 이유 : ErrorCode에서 Status와 code 한 번에 관리하기 위해서. 안그러면 ResponseEntity에서 status 따로, body 따로
+   * 쓰게 될 것임.. Global Exception Handler 참고 부탁
+   */
+  private ErrorResponse(int status, String code, String message) {
+    this.status = status;
+    this.code = code;
     this.message = message;
   }
+
+  public static ErrorResponse of(ErrorCode errorCode) {
+    return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage());
+  }
+
 }

--- a/src/main/java/com/prgrms/coretime/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/coretime/common/error/GlobalExceptionHandler.java
@@ -1,46 +1,91 @@
 package com.prgrms.coretime.common.error;
 
 
+import com.prgrms.coretime.common.ErrorCode;
+import com.prgrms.coretime.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+/**
+ * ErrorResponse에 status를 넣은 이유 ErrorResponse ErrorCode로부터 만들어서 status까지 관리
+ */
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-  // RequestBody
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-    log.warn(e.getMessage());
-    return ResponseEntity.badRequest().body("");
+
+  // 500 : Internal Server Error
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleServerException(Exception e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 
-  // ModelAttribute
+  // 405 : Method Not Allowed
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+      HttpRequestMethodNotSupportedException e) {
+    log.error(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+  }
+
+  // 400 : MethodArgumentNotValidException
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+  }
+
+  // 400 : MethodArgumentType
+  @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    log.error(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+  }
+
+  // 400 : Bad Request, ModelAttribute
   @ExceptionHandler(org.springframework.validation.BindException.class)
-  public ResponseEntity<String> handleBindException(BindException e) {
-    log.warn(e.getMessage());
-    return ResponseEntity.badRequest().body("");
+  public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-    log.warn(e.getMessage());
-    return ResponseEntity.badRequest().body("");
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
-    log.warn(e.getMessage());
-    return ResponseEntity.badRequest().body("");
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 
+  /**
+   * TODO - 400: Custom Index
+   */
   @ExceptionHandler(NotFoundException.class)
-  public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
-    log.warn(e.getMessage());
-    return ResponseEntity.badRequest().body("");
+  public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 }

--- a/src/main/java/com/prgrms/coretime/common/error/NotFoundException.java
+++ b/src/main/java/com/prgrms/coretime/common/error/NotFoundException.java
@@ -1,11 +1,15 @@
 package com.prgrms.coretime.common.error;
 
-public class NotFoundException extends RuntimeException{
-  public NotFoundException() {
-    super();
-  }
+import com.prgrms.coretime.common.ErrorCode;
+import lombok.Getter;
 
-  public NotFoundException(String message) {
-    super(message);
+@Getter
+public class NotFoundException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public NotFoundException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
   }
 }


### PR DESCRIPTION
## 구현 내용

### ErrorCode 작성

- 크게 쓰는 에러코드만 우선 작성하였고, 각자 작성할 때 필요한 비즈니스 예외 추가해서 사용하시며 될 것 같습니다.
- ErrorCode를 static 메서드인 fromMessage를 통해서 반환받도록 작성.

- 논의 사항
  - code 관리할 것인지...

### GlobalException Handler Refactoring

- 1. log에 stacktrace 추가

```java
log.warn(e.getMessage(), e);
```

- 2. ErrorResponse 팩토리메서드 사용
  - ErrorCode를 파라미터로 받아서 Response 생성

```java
  @ExceptionHandler(Exception.class)
  public ResponseEntity<ErrorResponse> handleServerException(Exception e) {
    log.warn(e.getMessage(), e);
    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
  }
```

### NOT FOUND Exception Refactoring

- 필드로 ErrorCode를 가지며, ErroCode를 통해서 생성

```java
@ExceptionHandler(NotFoundException.class)
  public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
    log.warn(e.getMessage(), e);
    ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode()); // 이부분 위해서 커스텀 예외들은 필드를 갖게 처리
    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
  }
```

</br>

제가 제안하는 방식은 하나의 대안이지 최선이 아닙니다.
우선 다같이 협의후 제가 피드백 반영하여 merge 하겠습니다.
