### PR TITLE
jwt 로컬 로그인 시 access token 발급 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/test/**/build/
 
 application-dev.yml
+application-test.yml
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ build/
 
 application-dev.yml
 application-test.yml
+data.sql
+import.sql
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-def querydslDir = "$buildDir/generated/querydsl"
+def querydslDir = "$buildDir/generated/querydsl" as Object
 
 querydsl {
 	jpa = true

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 	//swagger setting
 	implementation "io.springfox:springfox-boot-starter:3.0.0"
+
+	//jwt setting
+	implementation 'com.auth0:java-jwt:3.19.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prgrms/coretime/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
   METHOD_NOT_ALLOWED(405, "client01", "적절하지 않은 HTTP 메소드입니다."),
   INVALID_TYPE_VALUE(400, "client02", "요청 값의 타입이 잘못되었습니다."),
   INVALID_INPUT_VALUE(400, "client03", "적절하지 않은 요청값입니다."),
-  NOT_FOUND(404, "client04", "해당 리소스를 찾을 수 없습니다.");
+  NOT_FOUND(404, "client04", "해당 리소스를 찾을 수 없습니다."),
+  USER_NOT_FOUND(500, "U001", "유저가 존재하지 않습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "jwt")
 @Getter
 @Setter
-public class JwtConfigure {
+public class JwtConfig {
 
   private String header;
 

--- a/src/main/java/com/prgrms/coretime/common/config/JwtConfigure.java
+++ b/src/main/java/com/prgrms/coretime/common/config/JwtConfigure.java
@@ -1,5 +1,21 @@
 package com.prgrms.coretime.common.config;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
 public class JwtConfigure {
 
+  private String header;
+
+  private String issuer;
+
+  private String clientSecret;
+
+  private int expirySeconds;
 }

--- a/src/main/java/com/prgrms/coretime/common/config/JwtConfigure.java
+++ b/src/main/java/com/prgrms/coretime/common/config/JwtConfigure.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.config;
+
+public class JwtConfigure {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/config/RedisConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.prgrms.coretime.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.redis")
+@Getter
+@Setter
+public class RedisConfig {
+
+  private String host;
+
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    System.out.println(host);
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<String, String> redisTemplate() {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/common/config/SwaggerConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/SwaggerConfig.java
@@ -11,21 +11,22 @@ import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class SwaggerConfig {
-    @Bean
-    public Docket apiV1() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.ant("/api/v1/**"))
-                .build()
-                .apiInfo(apiInfo());
-    }
 
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder()
-                .title("Coretime API Docs")
-                .description("Descriptions of Coretime API")
-                .version("1.0")
-                .build();
-    }
+  @Bean
+  public Docket apiV1() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis(RequestHandlerSelectors.any())
+        .paths(PathSelectors.ant("/api/v1/**"))
+        .build()
+        .apiInfo(apiInfo());
+  }
+
+  private ApiInfo apiInfo() {
+    return new ApiInfoBuilder()
+        .title("Coretime API Docs")
+        .description("Descriptions of Coretime API")
+        .version("1.0")
+        .build();
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/config/WebConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/api/v1/**")
-        .allowedOrigins("*")
+        .allowedOriginPatterns("*")
         .allowedMethods(
             HttpMethod.GET.name(),
             HttpMethod.HEAD.name(),

--- a/src/main/java/com/prgrms/coretime/common/config/WebConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebConfig.java
@@ -7,16 +7,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/v1/**")
-                .allowedOrigins("*")
-                .allowedMethods(
-                        HttpMethod.GET.name(),
-                        HttpMethod.HEAD.name(),
-                        HttpMethod.POST.name(),
-                        HttpMethod.PUT.name(),
-                        HttpMethod.DELETE.name())
-                .allowCredentials(true);
-    }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/api/v1/**")
+        .allowedOrigins("*")
+        .allowedMethods(
+            HttpMethod.GET.name(),
+            HttpMethod.HEAD.name(),
+            HttpMethod.POST.name(),
+            HttpMethod.PUT.name(),
+            HttpMethod.DELETE.name())
+        .allowCredentials(true);
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.prgrms.coretime.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -9,6 +10,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    public void configure(WebSecurity web) {
+        web.ignoring().antMatchers("/assets/**", "/h2-console/**");
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -48,13 +48,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Bean
   @Override
-  public AuthenticationManager authenticationManager() throws Exception {
+  public AuthenticationManager authenticationManagerBean() throws Exception {
     return super.authenticationManagerBean();
-  }
-
-  @Autowired
-  public void configureAuthentication(AuthenticationManagerBuilder builder, JwtAuthenticationProvider authenticationProvider) {
-    builder.authenticationProvider(authenticationProvider);
   }
 
   public JwtAuthenticationFilter jwtAuthenticationFilter() {

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -72,6 +73,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .and()
         .authorizeRequests()
         .antMatchers("/swagger*/**").permitAll()
-        .antMatchers("/api/v1/**").permitAll();
+        .antMatchers("/api/v1/**").permitAll()
+        .and()
+        .addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);
   }
 }

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -13,36 +13,36 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
-    private final JwtConfigure jwtConfigure;
+  private final JwtConfigure jwtConfigure;
 
-    public WebSecurityConfig(JwtConfigure jwtConfigure) {
-        this.jwtConfigure = jwtConfigure;
-    }
+  public WebSecurityConfig(JwtConfigure jwtConfigure) {
+    this.jwtConfigure = jwtConfigure;
+  }
 
-    @Bean
-    public Jwt jwt() {
-        return new Jwt(
-            jwtConfigure.getIssuer(),
-            jwtConfigure.getClientSecret(),
-            jwtConfigure.getExpirySeconds()
-        );
-    }
+  @Bean
+  public Jwt jwt() {
+    return new Jwt(
+        jwtConfigure.getIssuer(),
+        jwtConfigure.getClientSecret(),
+        jwtConfigure.getExpirySeconds()
+    );
+  }
 
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/assets/**", "/h2-console/**");
-    }
+  @Override
+  public void configure(WebSecurity web) {
+    web.ignoring().antMatchers("/assets/**", "/h2-console/**");
+  }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-                .cors()
-                .and()
-                .csrf().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .authorizeRequests()
-                .antMatchers("/swagger*/**").permitAll()
-                .antMatchers("/api/v1/**").permitAll();
-    }
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http
+        .cors()
+        .and()
+        .csrf().disable()
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        .and()
+        .authorizeRequests()
+        .antMatchers("/swagger*/**").permitAll()
+        .antMatchers("/api/v1/**").permitAll();
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -26,6 +28,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         jwtConfigure.getClientSecret(),
         jwtConfigure.getExpirySeconds()
     );
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 
   @Override

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.prgrms.coretime.common.config;
 
+import com.prgrms.coretime.common.jwt.Jwt;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -10,6 +12,22 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtConfigure jwtConfigure;
+
+    public WebSecurityConfig(JwtConfigure jwtConfigure) {
+        this.jwtConfigure = jwtConfigure;
+    }
+
+    @Bean
+    public Jwt jwt() {
+        return new Jwt(
+            jwtConfigure.getIssuer(),
+            jwtConfigure.getClientSecret(),
+            jwtConfigure.getExpirySeconds()
+        );
+    }
+
     @Override
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers("/assets/**", "/h2-console/**");

--- a/src/main/java/com/prgrms/coretime/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/coretime/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.prgrms.coretime.common.error;
 
 
+import com.prgrms.coretime.common.error.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;

--- a/src/main/java/com/prgrms/coretime/common/error/exception/AuthErrorException.java
+++ b/src/main/java/com/prgrms/coretime/common/error/exception/AuthErrorException.java
@@ -1,0 +1,12 @@
+package com.prgrms.coretime.common.error.exception;
+
+public class AuthErrorException extends RuntimeException {
+
+  public AuthErrorException() {
+    super();
+  }
+
+  public AuthErrorException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/prgrms/coretime/common/error/exception/NotFoundException.java
+++ b/src/main/java/com/prgrms/coretime/common/error/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-package com.prgrms.coretime.common.error;
+package com.prgrms.coretime.common.error.exception;
 
 public class NotFoundException extends RuntimeException{
   public NotFoundException() {

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -48,6 +48,7 @@ public final class Jwt {
     }
     builder.withClaim("userId", claims.userId);
     builder.withClaim("nickname", claims.nickname);
+    builder.withArrayClaim("roles", claims.roles);
     return  builder.sign(algorithm);
   }
 
@@ -59,6 +60,7 @@ public final class Jwt {
 
     Long userId;
     String nickname;
+    String[] roles;
     Date iat; // 발행 시각
     Date exp; // 만료 시각
 
@@ -73,14 +75,19 @@ public final class Jwt {
       if (!nickname.isNull()) {
         this.nickname = nickname.asString();
       }
+      Claim roles = decodedJWT.getClaim("roles");
+      if (!roles.isNull()) {
+        this.roles = roles.asArray(String.class);
+      }
       this.iat = decodedJWT.getIssuedAt();
       this.exp = decodedJWT.getExpiresAt();
     }
 
-    public static Claims from(Long userId, String nickname) {
+    public static Claims from(Long userId, String nickname, String[] roles) {
       Claims claims = new Claims();
       claims.userId = userId;
       claims.nickname = nickname;
+      claims.roles = roles;
       return claims;
     }
   }

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -47,6 +47,7 @@ public final class Jwt {
       builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
     }
     builder.withClaim("userId", claims.userId);
+    builder.withClaim("nickname", claims.nickname);
     return  builder.sign(algorithm);
   }
 
@@ -57,6 +58,7 @@ public final class Jwt {
   static public class Claims {
 
     Long userId;
+    String nickname;
     Date iat; // 발행 시각
     Date exp; // 만료 시각
 
@@ -67,13 +69,18 @@ public final class Jwt {
       if (!userId.isNull()) {
         this.userId = userId.asLong();
       }
+      Claim nickname = decodedJWT.getClaim("nickname");
+      if (!nickname.isNull()) {
+        this.nickname = nickname.asString();
+      }
       this.iat = decodedJWT.getIssuedAt();
       this.exp = decodedJWT.getExpiresAt();
     }
 
-    public static Claims from(Long userId) {
+    public static Claims from(Long userId, String nickname) {
       Claims claims = new Claims();
       claims.userId = userId;
+      claims.nickname = nickname;
       return claims;
     }
   }

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -48,6 +48,8 @@ public final class Jwt {
     }
     builder.withClaim("userId", claims.userId);
     builder.withClaim("nickname", claims.nickname);
+    builder.withClaim("email", claims.email);
+    builder.withClaim("schoolId", claims.schoolId);
     builder.withArrayClaim("roles", claims.roles);
     return  builder.sign(algorithm);
   }
@@ -59,7 +61,9 @@ public final class Jwt {
   static public class Claims {
 
     Long userId;
+    Long schoolId;
     String nickname;
+    String email;
     String[] roles;
     Date iat; // 발행 시각
     Date exp; // 만료 시각
@@ -71,9 +75,17 @@ public final class Jwt {
       if (!userId.isNull()) {
         this.userId = userId.asLong();
       }
+      Claim schoolId = decodedJWT.getClaim("schoolId");
+      if (!schoolId.isNull()) {
+        this.schoolId = schoolId.asLong();
+      }
       Claim nickname = decodedJWT.getClaim("nickname");
       if (!nickname.isNull()) {
         this.nickname = nickname.asString();
+      }
+      Claim email = decodedJWT.getClaim("email");
+      if (!email.isNull()) {
+        this.email = email.asString();
       }
       Claim roles = decodedJWT.getClaim("roles");
       if (!roles.isNull()) {
@@ -83,10 +95,12 @@ public final class Jwt {
       this.exp = decodedJWT.getExpiresAt();
     }
 
-    public static Claims from(Long userId, String nickname, String[] roles) {
+    public static Claims from(Long userId, Long schoolId, String nickname, String email, String[] roles) {
       Claims claims = new Claims();
       claims.userId = userId;
+      claims.schoolId = schoolId;
       claims.nickname = nickname;
+      claims.email = email;
       claims.roles = roles;
       return claims;
     }

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -1,0 +1,81 @@
+package com.prgrms.coretime.common.jwt;
+
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import lombok.Getter;
+
+/*
+ * Jwt
+ * - Jwt 토큰의 정보 소유
+ * - Jwt 토큰 발행 (sign)
+ * - Jwt 토큰 검증 (verify)
+ * */
+@Getter
+public final class Jwt {
+
+  private final String issuer;
+
+  private final String clientSecret;
+
+  private final int expirySeconds;
+
+  private final Algorithm algorithm;
+
+  private final JWTVerifier jwtVerifier;
+
+  public Jwt(String issuer, String clientSecret, int expirySeconds) {
+    this.issuer = issuer;
+    this.clientSecret = clientSecret;
+    this.expirySeconds = expirySeconds;
+    this.algorithm = Algorithm.HMAC512(clientSecret);
+    this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
+        .withIssuer(issuer)
+        .build();
+  }
+
+  public String sign(Claims claims){
+    Date now = new Date();
+    JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+    builder.withIssuer(issuer);
+    builder.withIssuedAt(now);
+    if(expirySeconds > 0) {
+      builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+    }
+    builder.withClaim("userId", claims.userId);
+    return  builder.sign(algorithm);
+  }
+
+  public Claims verify(String token) throws JWTVerificationException {
+    return new Claims(jwtVerifier.verify(token));
+  }
+
+  static public class Claims {
+
+    Long userId;
+    Date iat; // 발행 시각
+    Date exp; // 만료 시각
+
+    private Claims() {/*no-ops*/}
+
+    Claims(DecodedJWT decodedJWT) {
+      Claim userId = decodedJWT.getClaim("userId");
+      if (!userId.isNull()) {
+        this.userId = userId.asLong();
+      }
+      this.iat = decodedJWT.getIssuedAt();
+      this.exp = decodedJWT.getExpiresAt();
+    }
+
+    public static Claims from(Long userId) {
+      Claims claims = new Claims();
+      claims.userId = userId;
+      return claims;
+    }
+  }
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
@@ -1,6 +1,0 @@
-package com.prgrms.coretime.common.jwt;
-
-public class JwtAuthentication {
-
-
-}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
@@ -2,4 +2,5 @@ package com.prgrms.coretime.common.jwt;
 
 public class JwtAuthentication {
 
+
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthentication.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.jwt;
+
+public class JwtAuthentication {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
@@ -48,14 +48,16 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
           log.debug("Jwt parse result: {}", claims);
 
           String nickname = claims.nickname;
+          String email = claims.email;
           Long userId = claims.userId;
+          Long schoolId= claims.schoolId;
           List<GrantedAuthority> authorities = getAuthorities(claims);
 
-          if ((nickname != null && !nickname.equals(""))
+          if ((nickname != null && !nickname.trim().equals(""))
               && userId != null
               && authorities.size() > 0
           ) {
-            JwtAuthenticationToken authentication = new JwtAuthenticationToken(new JwtPrincipal(token, nickname, userId), null,authorities);
+            JwtAuthenticationToken authentication = new JwtAuthenticationToken(new JwtPrincipal(token, nickname, email, userId, schoolId), null,authorities);
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);
           }
@@ -72,7 +74,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
   private String getToken(HttpServletRequest request) {
     String token = request.getHeader(headerKey);
-    if(token == null || token.equals("")) {
+    if(token != null && !token.trim().equals("")) {
       log.debug("Jwt authorization api detected: {}", token);
       try {
         return URLDecoder.decode(token, "UTF-8");

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,95 @@
 package com.prgrms.coretime.common.jwt;
 
-public class JwtAuthenticationFilter {
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.GenericFilterBean;
 
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final String headerKey;
+
+  private final Jwt jwt;
+
+  public JwtAuthenticationFilter(String headerKey, Jwt jwt) {
+    this.headerKey = headerKey;
+    this.jwt = jwt;
+  }
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest request = (HttpServletRequest) req;
+    HttpServletResponse response = (HttpServletResponse) res;
+
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      String token = getToken(request);
+      if (token != null) {
+        try {
+          Jwt.Claims claims = verify(token);
+          log.debug("Jwt parse result: {}", claims);
+
+          String nickname = claims.nickname;
+          Long userId = claims.userId;
+          List<GrantedAuthority> authorities = getAuthorities(claims);
+
+          if ((nickname != null && !nickname.equals(""))
+              && userId != null
+              && authorities.size() > 0
+          ) {
+            JwtAuthenticationToken authentication = new JwtAuthenticationToken(new JwtPrincipal(token, nickname, userId), null,authorities);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+          }
+        } catch (Exception e) {
+          log.warn("Jwt processing failed: {}", e.getMessage());
+        }
+      }
+    } else {
+      log.debug("SecurityContextHolder not populated with security token, as it already contained: '{}'", SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  private String getToken(HttpServletRequest request) {
+    String token = request.getHeader(headerKey);
+    if(token == null || token.equals("")) {
+      log.debug("Jwt authorization api detected: {}", token);
+      try {
+        return URLDecoder.decode(token, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        log.error(e.getMessage(), e);
+      }
+    }
+    return null;
+  }
+
+  private Jwt.Claims verify(String token) {
+    return jwt.verify(token);
+  }
+
+  private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {
+    String[] roles = claims.roles;
+    return roles == null || roles.length == 0 ? Collections.emptyList() : Arrays.stream(roles).map(
+        SimpleGrantedAuthority::new).collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.jwt;
+
+public class JwtAuthenticationFilter {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.jwt;
+
+public class JwtAuthenticationProvider {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
@@ -43,8 +43,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
       User user = userService.login(principal, credentials);
       // TODO : 확장성 고려할 것
       List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("USER"));
-      String token = getToken(user.getId(), user.getNickname(), authorities);
-      JwtAuthenticationToken authenticated = new JwtAuthenticationToken(new JwtPrincipal(token, user.getNickname(), user.getId()), null, authorities);
+      String token = getToken(user.getId(), user.getSchool().getId(), user.getNickname(), user.getEmail(), authorities);
+      JwtAuthenticationToken authenticated = new JwtAuthenticationToken(new JwtPrincipal(token, user.getNickname(), user.getEmail(), user.getId(), user.getSchool().getId()), null, authorities);
       authenticated.setDetails(user);
       return authenticated;
     } catch (IllegalArgumentException e) {
@@ -54,10 +54,10 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     }
   }
 
-  private String getToken(Long userId, String nickname, List<GrantedAuthority> authorities) {
+  private String getToken(Long userId, Long schoolId, String nickname, String email, List<GrantedAuthority> authorities) {
     String[] roles = authorities.stream()
         .map(GrantedAuthority::getAuthority)
         .toArray(String[]::new);
-    return jwt.sign(Jwt.Claims.from(userId, nickname, roles));
+    return jwt.sign(Jwt.Claims.from(userId, schoolId, nickname, email, roles));
   }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.Assert;
 
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
@@ -33,7 +34,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
   @Override
   public boolean supports(Class<?> authentication) {
-    return false;
+    Assert.isAssignable(authentication, JwtAuthenticationToken.class);
+    return true;
   }
 
   private Authentication processUserAuthentication(String principal, String credentials) {

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
@@ -1,5 +1,44 @@
 package com.prgrms.coretime.common.jwt;
 
-public class JwtAuthenticationProvider {
+import com.prgrms.coretime.user.domain.User;
+import com.prgrms.coretime.user.service.UserService;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+  private final Jwt jwt;
+
+  private final UserService userService;
+
+  public JwtAuthenticationProvider(Jwt jwt, UserService userService) {
+    this.jwt = jwt;
+    this.userService = userService;
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+    return null;
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return false;
+  }
+
+  private Authentication processUserAuthentication(String principal, String credentials) {
+    try{
+//      User user =
+    } catch (IllegalArgumentException e) {
+      throw new BadCredentialsException(e.getMessage());
+    } catch (DataAccessException e) {
+      throw new AuthenticationServiceException(e.getMessage(), e);
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.jwt;
+
+public class JwtAuthenticationToken {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
@@ -1,5 +1,51 @@
 package com.prgrms.coretime.common.jwt;
 
-public class JwtAuthenticationToken {
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+  private final Object principal;
+
+  private String credentials;
+
+  public JwtAuthenticationToken(String principal, String credentials) {
+    super(null);
+    super.setAuthenticated(false);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    super.setAuthenticated(true);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  @Override
+  public Object getCredentials() {
+    return principal;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return credentials;
+  }
+
+  public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    if (isAuthenticated) {
+      throw new IllegalArgumentException("Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead.");
+    }
+    super.setAuthenticated(false);
+  }
+
+  @Override
+  public void eraseCredentials() {
+    super.eraseCredentials();;
+    credentials = null;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
@@ -27,13 +27,13 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
   }
 
   @Override
-  public Object getCredentials() {
-    return principal;
+  public String getCredentials() {
+    return credentials;
   }
 
   @Override
   public Object getPrincipal() {
-    return credentials;
+    return principal;
   }
 
   public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationToken.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
   @Override
   public void eraseCredentials() {
-    super.eraseCredentials();;
+    super.eraseCredentials();
     credentials = null;
   }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
@@ -1,0 +1,23 @@
+package com.prgrms.coretime.common.jwt;
+
+import java.util.MissingFormatArgumentException;
+import org.springframework.util.Assert;
+
+public class JwtPrincipal {
+
+  public final String token;
+
+  public final String nickname;
+
+  public final Long userId;
+
+  JwtPrincipal(String token, String nickname, Long userId) {
+    Assert.hasText(token, "token이 공백이거나 누락되었습니다.");
+    Assert.hasText(nickname, "nickname이 공백이거나 누락되었습니다.");
+    Assert.notNull(userId,"userId가 누락되었습니다.");
+
+    this.token = token;
+    this.nickname = nickname;
+    this.userId = userId;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
@@ -8,15 +8,23 @@ public class JwtPrincipal {
 
   public final String nickname;
 
+  public final String email;
+
   public final Long userId;
 
-  JwtPrincipal(String token, String nickname, Long userId) {
+  public final Long schoolId;
+
+  JwtPrincipal(String token, String nickname, String email, Long userId, Long schoolId) {
     Assert.hasText(token, "token이 공백이거나 누락되었습니다.");
     Assert.hasText(nickname, "nickname이 공백이거나 누락되었습니다.");
+    Assert.hasText(email, "email 공백이거나 누락되었습니다.");
     Assert.notNull(userId,"userId가 누락되었습니다.");
+    Assert.notNull(schoolId,"schoolId가 누락되었습니다.");
 
     this.token = token;
     this.nickname = nickname;
+    this.email = email;
     this.userId = userId;
+    this.schoolId = schoolId;
   }
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtPrincipal.java
@@ -1,6 +1,5 @@
 package com.prgrms.coretime.common.jwt;
 
-import java.util.MissingFormatArgumentException;
 import org.springframework.util.Assert;
 
 public class JwtPrincipal {

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtSecurityContextRepository.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtSecurityContextRepository.java
@@ -1,0 +1,5 @@
+package com.prgrms.coretime.common.jwt;
+
+public class JwtSecurityContextRepository {
+
+}

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtSecurityContextRepository.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtSecurityContextRepository.java
@@ -1,5 +1,0 @@
-package com.prgrms.coretime.common.jwt;
-
-public class JwtSecurityContextRepository {
-
-}

--- a/src/main/java/com/prgrms/coretime/common/util/RedisService.java
+++ b/src/main/java/com/prgrms/coretime/common/util/RedisService.java
@@ -1,0 +1,36 @@
+package com.prgrms.coretime.common.util;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public RedisService(
+      RedisTemplate<String, String> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public void setValues(String key, String data) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    values.set(key, data);
+  }
+
+  public void setValues(String key, String data, Duration duration) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    values.set(key, data, duration);
+  }
+
+  public String getValues(String key) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    return values.get(key);
+  }
+
+  public void deleteValues(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/prgrms/coretime/common/util/Tmp.java
+++ b/src/main/java/com/prgrms/coretime/common/util/Tmp.java
@@ -1,5 +1,0 @@
-package com.prgrms.coretime.common.util;
-
-public class Tmp {
-
-}

--- a/src/main/java/com/prgrms/coretime/friend/domain/Friend.java
+++ b/src/main/java/com/prgrms/coretime/friend/domain/Friend.java
@@ -39,7 +39,7 @@ public class Friend extends BaseEntity {
   )
   private User followeeUser;
 
-  public void setFollowerUser(User followerUser) {
+  /*public void setFollowerUser(User followerUser) {
     if (Objects.nonNull(this.followerUser)) {
       followerUser.getFollowers().remove(this);
     }
@@ -53,5 +53,5 @@ public class Friend extends BaseEntity {
     }
     this.followeeUser = followeeUser;
     followeeUser.getFollowees().add(this);
-  }
+  }*/
 }

--- a/src/main/java/com/prgrms/coretime/message/domain/Message.java
+++ b/src/main/java/com/prgrms/coretime/message/domain/Message.java
@@ -45,12 +45,12 @@ public class Message extends BaseEntity {
     messageRoom.getMessages().add(this);
   }
 
-  public void setWriter(User writer) {
+  /*public void setWriter(User writer) {
     if (Objects.nonNull(this.writer)) {
       writer.getMessageWriters().remove(this);
     }
     this.writer = writer;
     writer.getMessageWriters().add(this);
-  }
+  }*/
 
 }

--- a/src/main/java/com/prgrms/coretime/message/domain/MessageRoom.java
+++ b/src/main/java/com/prgrms/coretime/message/domain/MessageRoom.java
@@ -48,7 +48,7 @@ public class MessageRoom extends BaseEntity {
   @OneToMany(mappedBy = "messageRoom")
   private List<Message> messages = new ArrayList<>();
 
-  public void setInitialSender(User initialSender) {
+  /*public void setInitialSender(User initialSender) {
     if (Objects.nonNull(this.initialSender)) {
       initialSender.getMessageRoomInitialSenders().remove(this);
     }
@@ -63,6 +63,6 @@ public class MessageRoom extends BaseEntity {
     }
     this.initialReceiver = initialReceiver;
     initialReceiver.getMessageRoomInitialReceivers().add(this);
-  }
+  }*/
 
 }

--- a/src/main/java/com/prgrms/coretime/school/domain/School.java
+++ b/src/main/java/com/prgrms/coretime/school/domain/School.java
@@ -25,4 +25,10 @@ public class School extends BaseEntity {
 
   @Column(name = "email", nullable = false, length = 300)
   private String email;
+
+  public School(Long id, String name, String email) {
+    this.id = id;
+    this.name = name;
+    this.email = email;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/school/domain/School.java
+++ b/src/main/java/com/prgrms/coretime/school/domain/School.java
@@ -8,11 +8,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "school")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class School extends BaseEntity {
 
   @Id
@@ -20,15 +22,19 @@ public class School extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
-  @Column(name = "name", nullable = false, length = 30)
+  @Column(name = "name", nullable = false, length = 30, unique = true)
   private String name;
 
-  @Column(name = "email", nullable = false, length = 300)
+  @Column(name = "email", nullable = false, length = 300, unique = true)
   private String email;
 
-  public School(Long id, String name, String email) {
-    this.id = id;
+  public School(String name, String email) {
     this.name = name;
     this.email = email;
+  }
+
+  // TODO : test 용
+  public void setId(Long id) {
+    this.id = id;
   }
 }

--- a/src/main/java/com/prgrms/coretime/school/domain/respository/SchoolRepository.java
+++ b/src/main/java/com/prgrms/coretime/school/domain/respository/SchoolRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.coretime.school.domain.respository;
+
+import com.prgrms.coretime.school.domain.School;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchoolRepository extends JpaRepository<School, Long> {
+
+}

--- a/src/main/java/com/prgrms/coretime/user/controller/Tmp.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/Tmp.java
@@ -1,5 +1,0 @@
-package com.prgrms.coretime.user.controller;
-
-public class Tmp {
-
-}

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -9,6 +9,8 @@ import com.prgrms.coretime.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,5 +44,8 @@ public class UserController {
     return null;
   }
 
-
+  @GetMapping("/principal")
+  public ResponseEntity<ApiResponse<JwtPrincipal>> getPrincipalInfo(@AuthenticationPrincipal JwtPrincipal principal) {
+    return ResponseEntity.ok(new ApiResponse<>("현재 로그인한 사용자입니다.", principal));
+  }
 }

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -1,0 +1,45 @@
+package com.prgrms.coretime.user.controller;
+
+import com.prgrms.coretime.common.ApiResponse;
+import com.prgrms.coretime.common.jwt.JwtAuthenticationToken;
+import com.prgrms.coretime.common.jwt.JwtPrincipal;
+import com.prgrms.coretime.user.dto.request.UserLocalLoginRequest;
+import com.prgrms.coretime.user.dto.response.UserResponse;
+import com.prgrms.coretime.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/users")
+public class UserController {
+
+  private final UserService userService;
+
+  private final AuthenticationManager authenticationManager;
+
+  public UserController(UserService userService,
+      AuthenticationManager authenticationManager) {
+    this.userService = userService;
+    this.authenticationManager = authenticationManager;
+  }
+
+  @PostMapping("/local/login")
+  public ResponseEntity<ApiResponse<UserResponse>> localLogin(@RequestBody UserLocalLoginRequest request) {
+    JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getEmail(),
+        request.getPassword());
+    Authentication resultToken = authenticationManager.authenticate(authToken);
+    JwtPrincipal principal = (JwtPrincipal) resultToken.getPrincipal();
+    return ResponseEntity.ok(new ApiResponse<>("로그인 성공", new UserResponse(
+        principal.token, true)));
+  }
+
+  @PostMapping("/oauth/login")
+  public ResponseEntity<ApiResponse<UserResponse>> oauthLogin(@RequestBody UserLocalLoginRequest request) {
+    return null;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -4,7 +4,7 @@ import com.prgrms.coretime.common.ApiResponse;
 import com.prgrms.coretime.common.jwt.JwtAuthenticationToken;
 import com.prgrms.coretime.common.jwt.JwtPrincipal;
 import com.prgrms.coretime.user.dto.request.UserLocalLoginRequest;
-import com.prgrms.coretime.user.dto.response.UserResponse;
+import com.prgrms.coretime.user.dto.response.LoginResponse;
 import com.prgrms.coretime.user.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,17 +29,16 @@ public class UserController {
   }
 
   @PostMapping("/local/login")
-  public ResponseEntity<ApiResponse<UserResponse>> localLogin(@RequestBody UserLocalLoginRequest request) {
+  public ResponseEntity<ApiResponse<LoginResponse>> localLogin(@RequestBody UserLocalLoginRequest request) {
     JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getEmail(),
         request.getPassword());
     Authentication resultToken = authenticationManager.authenticate(authToken);
     JwtPrincipal principal = (JwtPrincipal) resultToken.getPrincipal();
-    return ResponseEntity.ok(new ApiResponse<>("로그인 성공", new UserResponse(
-        principal.token, true)));
+    return ResponseEntity.ok(new ApiResponse<>("로그인 성공", new LoginResponse(principal.token, true)));
   }
 
   @PostMapping("/oauth/login")
-  public ResponseEntity<ApiResponse<UserResponse>> oauthLogin(@RequestBody UserLocalLoginRequest request) {
+  public ResponseEntity<ApiResponse<LoginResponse>> oauthLogin(@RequestBody UserLocalLoginRequest request) {
     return null;
   }
 }

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -41,4 +41,6 @@ public class UserController {
   public ResponseEntity<ApiResponse<LoginResponse>> oauthLogin(@RequestBody UserLocalLoginRequest request) {
     return null;
   }
+
+
 }

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -46,6 +46,13 @@ public class UserController {
 
   @GetMapping("/principal")
   public ResponseEntity<ApiResponse<JwtPrincipal>> getPrincipalInfo(@AuthenticationPrincipal JwtPrincipal principal) {
+    /*
+    * principal.email
+    * principal.schoolId
+    * principal.userId
+    * principal.nickname
+    * principal.token
+    * */
     return ResponseEntity.ok(new ApiResponse<>("현재 로그인한 사용자입니다.", principal));
   }
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/LocalUser.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/LocalUser.java
@@ -1,5 +1,6 @@
 package com.prgrms.coretime.user.domain;
 
+import com.prgrms.coretime.common.error.exception.AuthErrorException;
 import com.prgrms.coretime.school.domain.School;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -9,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @DiscriminatorValue("LOCAL")
@@ -24,4 +26,8 @@ public class LocalUser extends User {
     this.password = password;
   }
 
+  public void checkPassword(PasswordEncoder passwordEncoder, String credentials) {
+    if (!passwordEncoder.matches(credentials, password))
+      throw new AuthErrorException("Bad credential");
+  }
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/LocalUser.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/LocalUser.java
@@ -1,13 +1,27 @@
 package com.prgrms.coretime.user.domain;
 
+import com.prgrms.coretime.school.domain.School;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @DiscriminatorValue("LOCAL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LocalUser extends User {
 
   @Column(name = "password")
   private String password;
+
+  @Builder
+  public LocalUser(School school, String email, String profileImage, String nickname, String name, String password) {
+    super(school, email, profileImage, nickname, name);
+    this.password = password;
+  }
+
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/OAuthUser.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/OAuthUser.java
@@ -1,11 +1,18 @@
 package com.prgrms.coretime.user.domain;
 
+import com.prgrms.coretime.school.domain.School;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @DiscriminatorValue("OAUTH")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OAuthUser extends User{
 
   @Column(name = "provider")
@@ -13,4 +20,11 @@ public class OAuthUser extends User{
 
   @Column(name = "provider_id")
   private String providerId;
+
+  @Builder
+  public OAuthUser(School school, String email, String profileImage, String nickname, String name, String provider, String providerId) {
+    super(school, email, profileImage, nickname, name);
+    this.provider = provider;
+    this.providerId = providerId;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/OAuthUser.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/OAuthUser.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @DiscriminatorValue("OAUTH")

--- a/src/main/java/com/prgrms/coretime/user/domain/User.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/User.java
@@ -56,7 +56,6 @@ public class User extends BaseEntity {
   private String name;
 
   public User (School school, String email, String profileImage, String nickname, String name) {
-    this.id = id;
     this.school = school;
     this.email = email;
     this.profileImage = profileImage;

--- a/src/main/java/com/prgrms/coretime/user/domain/User.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/User.java
@@ -20,8 +20,11 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,31 +43,24 @@ public class User extends BaseEntity {
   @JoinColumn(name = "school_id")
   private School school;
 
-  @Column(name = "email")
+  @Column(name = "email", unique = true)
   private String email;
 
   @Column(name = "profile_image")
   private String profileImage;
 
-  @Column(name = "nickname")
+  @Column(name = "nickname", unique = true)
   private String nickname;
 
   @Column(name = "name")
   private String name;
 
-  @OneToMany(mappedBy = "followerUser")
-  private List<Friend> followers = new ArrayList<>();
-
-  @OneToMany(mappedBy = "followeeUser")
-  private List<Friend> followees = new ArrayList<>();
-
-  @OneToMany(mappedBy = "writer")
-  private List<Message> messageWriters = new ArrayList<>();
-
-  @OneToMany(mappedBy = "initialSender")
-  private List<MessageRoom> messageRoomInitialSenders = new ArrayList<>();
-
-  @OneToMany(mappedBy = "initialReceiver")
-  private List<MessageRoom> messageRoomInitialReceivers = new ArrayList<>();
-
+  public User (School school, String email, String profileImage, String nickname, String name) {
+    this.id = id;
+    this.school = school;
+    this.email = email;
+    this.profileImage = profileImage;
+    this.nickname = nickname;
+    this.name = name;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/User.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/User.java
@@ -62,4 +62,9 @@ public class User extends BaseEntity {
     this.nickname = nickname;
     this.name = name;
   }
+
+  // TODO : test 용
+  public void setId(Long id) {
+    this.id = id;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/LocalUserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/LocalUserRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.coretime.user.domain.repository;
+
+import com.prgrms.coretime.user.domain.LocalUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocalUserRepository extends JpaRepository<LocalUser, Long> {
+
+}

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/OAuthUserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/OAuthUserRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.coretime.user.domain.repository;
+
+import com.prgrms.coretime.user.domain.OAuthUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthUserRepository extends JpaRepository<OAuthUser, Long> {
+
+}

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.prgrms.coretime.user.domain.repository;
+
+import com.prgrms.coretime.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
@@ -10,4 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   @Query("select u from User u join fetch u.school s where u.email = :email")
   Optional<User> findByEmail(String email);
+
+  @Query("select u from User u join fetch u.school s where u.nickname = :nickname")
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  @Query("select u from User u join fetch u.school s where u.email = :email")
   Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.prgrms.coretime.user.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 

--- a/src/main/java/com/prgrms/coretime/user/dto/request/Tmp.java
+++ b/src/main/java/com/prgrms/coretime/user/dto/request/Tmp.java
@@ -1,5 +1,0 @@
-package com.prgrms.coretime.user.dto.request;
-
-public class Tmp {
-
-}

--- a/src/main/java/com/prgrms/coretime/user/dto/request/UserLocalLoginRequest.java
+++ b/src/main/java/com/prgrms/coretime/user/dto/request/UserLocalLoginRequest.java
@@ -1,0 +1,15 @@
+package com.prgrms.coretime.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserLocalLoginRequest {
+  private final String email;
+
+  private final String password;
+
+  public UserLocalLoginRequest(String email, String password) {
+    this.email = email;
+    this.password = password;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/prgrms/coretime/user/dto/response/LoginResponse.java
@@ -3,13 +3,13 @@ package com.prgrms.coretime.user.dto.response;
 import lombok.Getter;
 
 @Getter
-public class UserResponse {
+public class LoginResponse {
 
   private final String accessToken;
 
   private final Boolean isLocal;
 
-  public UserResponse(String accessToken, Boolean isLocal) {
+  public LoginResponse(String accessToken, Boolean isLocal) {
     this.accessToken = accessToken;
     this.isLocal = isLocal;
   }

--- a/src/main/java/com/prgrms/coretime/user/dto/response/Tmp.java
+++ b/src/main/java/com/prgrms/coretime/user/dto/response/Tmp.java
@@ -1,5 +1,0 @@
-package com.prgrms.coretime.user.dto.response;
-
-public class Tmp {
-
-}

--- a/src/main/java/com/prgrms/coretime/user/dto/response/UserResponse.java
+++ b/src/main/java/com/prgrms/coretime/user/dto/response/UserResponse.java
@@ -1,0 +1,16 @@
+package com.prgrms.coretime.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+
+  private final String accessToken;
+
+  private final Boolean isLocal;
+
+  public UserResponse(String accessToken, Boolean isLocal) {
+    this.accessToken = accessToken;
+    this.isLocal = isLocal;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -1,6 +1,45 @@
 
 package com.prgrms.coretime.user.service;
 
+import com.prgrms.coretime.common.error.exception.NotFoundException;
+import com.prgrms.coretime.user.domain.LocalUser;
+import com.prgrms.coretime.user.domain.User;
+import com.prgrms.coretime.user.domain.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Service
 public class UserService {
+
+  private final PasswordEncoder passwordEncoder;
+
+  private final UserRepository userRepository;
+
+
+  public UserService(PasswordEncoder passwordEncoder,
+      UserRepository userRepository) {
+    this.passwordEncoder = passwordEncoder;
+    this.userRepository = userRepository;
+  }
+
+  // TODO : oauth 고려
+  public User login(String principal, String credentials) {
+    Assert.hasText(principal, "principal이 누락되었습니다.");
+    Assert.hasText(credentials, "credentials이 누락되었습니다.");
+
+    LocalUser user = (LocalUser) userRepository.findByEmail(principal).orElseThrow(() -> new NotFoundException("유저가 존재하지 않습니다."));
+    user.checkPassword(passwordEncoder, credentials);
+    return user;
+  }
+
+  // TODO : message 관리
+  @Transactional(readOnly = true)
+  public User findByEmail(String email) {
+    Assert.hasText(email, "email이 누락되었습니다.");
+    return userRepository.findByEmail(email)
+        .orElseThrow(() -> new NotFoundException("유저가 존재하지 않습니다."));
+  }
 
 }

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import static com.prgrms.coretime.common.ErrorCode.*;
+
 @Service
 public class UserService {
 
@@ -30,7 +32,7 @@ public class UserService {
     Assert.hasText(principal, "principal이 누락되었습니다.");
     Assert.hasText(credentials, "credentials이 누락되었습니다.");
 
-    LocalUser user = (LocalUser) userRepository.findByEmail(principal).orElseThrow(() -> new NotFoundException("유저가 존재하지 않습니다."));
+    LocalUser user = (LocalUser) userRepository.findByEmail(principal).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     user.checkPassword(passwordEncoder, credentials);
     return user;
   }
@@ -40,7 +42,7 @@ public class UserService {
   public User findByEmail(String email) {
     Assert.hasText(email, "email이 누락되었습니다.");
     return userRepository.findByEmail(email)
-        .orElseThrow(() -> new NotFoundException("유저가 존재하지 않습니다."));
+        .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
   }
 
   @Transactional

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -1,6 +1,6 @@
 
 package com.prgrms.coretime.user.service;
 
-public class Tmp {
+public class UserService {
 
 }

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -24,7 +24,8 @@ public class UserService {
     this.userRepository = userRepository;
   }
 
-  // TODO : oauth 고려
+  // TODO : oauth 고려, register 부분도
+  @Transactional
   public User login(String principal, String credentials) {
     Assert.hasText(principal, "principal이 누락되었습니다.");
     Assert.hasText(credentials, "credentials이 누락되었습니다.");
@@ -40,6 +41,12 @@ public class UserService {
     Assert.hasText(email, "email이 누락되었습니다.");
     return userRepository.findByEmail(email)
         .orElseThrow(() -> new NotFoundException("유저가 존재하지 않습니다."));
+  }
+
+  @Transactional
+  // TODO : 임시 회원가입 구현. 인증 구현해야 함.
+  public User register() {
+    return null;
   }
 
 }

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -37,11 +37,17 @@ public class UserService {
     return user;
   }
 
-  // TODO : message 관리
   @Transactional(readOnly = true)
   public User findByEmail(String email) {
     Assert.hasText(email, "email이 누락되었습니다.");
     return userRepository.findByEmail(email)
+        .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  public User findByNickname(String nickname) {
+    Assert.hasText(nickname, "nickname이 누락되었습니다.");
+    return userRepository.findByNickname(nickname)
         .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
 jwt:
-  header: token
+  header: accessToken
   issuer: victory
   client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
   expiry-seconds: 60*30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   redis:
-    host: redis_dev
+    host: localhost
     port: 6379
     password:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,8 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+jwt:
+  header: token
+  issuer: victory
+  client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
+  expiry-seconds: 60*30

--- a/src/test/java/com/prgrms/coretime/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/coretime/user/controller/UserControllerTest.java
@@ -1,0 +1,14 @@
+package com.prgrms.coretime.user.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+  @Test
+  void testLocalLogin() {
+  }
+}

--- a/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.prgrms.coretime.user.domain.repository;
+
+import com.prgrms.coretime.common.error.NotFoundException;
+import com.prgrms.coretime.school.domain.School;
+import com.prgrms.coretime.school.domain.respository.SchoolRepository;
+import com.prgrms.coretime.user.domain.LocalUser;
+import com.prgrms.coretime.user.domain.OAuthUser;
+import com.prgrms.coretime.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles({"test"})
+class UserRepositoryTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private SchoolRepository schoolRepository;
+
+  @Test
+  @DisplayName("UserRepository를 통해 LocalUser와 OAuthUser instance를 가져올 수 있다.")
+  void testFindByEmail() throws Throwable {
+    School testSchool = new School(1L, "아주대학교", "ajou.ac.kr");
+    String localTestEmail = "local@ajou.ac.kr";
+    String oauthTestEmail = "oauth@ajou.ac.kr";
+    User user1 = LocalUser.builder()
+        .nickname("로컬유저")
+        .profileImage("예시 링크")
+        .email(localTestEmail)
+        .nickname("빈푸")
+        .name("김승은로컬")
+        .school(testSchool)
+        .password("test1234!")
+        .build();
+    User user2 = OAuthUser.builder()
+        .nickname("oauthuser")
+        .profileImage("예시 링크")
+        .nickname("자바빈")
+        .email(oauthTestEmail)
+        .name("김승은oauth")
+        .school(testSchool)
+        .provider("카카오")
+        .providerId("카카오id")
+        .build();
+
+    schoolRepository.save(testSchool);
+    userRepository.save(user1);
+    userRepository.save(user2);
+
+    User localResult = userRepository.findByEmail(localTestEmail).orElseThrow(() -> new NotFoundException("local user를 찾을 수 없습니다."));
+    User oauthResult = userRepository.findByEmail(oauthTestEmail).orElseThrow(() -> new NotFoundException("local user를 찾을 수 없습니다."));
+
+    assertThat(localResult).isInstanceOf(LocalUser.class);
+    assertThat(oauthResult).isInstanceOf(OAuthUser.class);
+  }
+}

--- a/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.coretime.user.domain.repository;
 
-import com.prgrms.coretime.common.error.NotFoundException;
+import com.prgrms.coretime.common.error.exception.NotFoundException;
 import com.prgrms.coretime.school.domain.School;
 import com.prgrms.coretime.school.domain.respository.SchoolRepository;
 import com.prgrms.coretime.user.domain.LocalUser;
@@ -31,18 +31,16 @@ class UserRepositoryTest {
     String localTestEmail = "local@ajou.ac.kr";
     String oauthTestEmail = "oauth@ajou.ac.kr";
     User user1 = LocalUser.builder()
-        .nickname("로컬유저")
+        .nickname("local유저")
         .profileImage("예시 링크")
         .email(localTestEmail)
-        .nickname("빈푸")
         .name("김승은로컬")
         .school(testSchool)
         .password("test1234!")
         .build();
     User user2 = OAuthUser.builder()
-        .nickname("oauthuser")
+        .nickname("oauth유저")
         .profileImage("예시 링크")
-        .nickname("자바빈")
         .email(oauthTestEmail)
         .name("김승은oauth")
         .school(testSchool)
@@ -55,9 +53,11 @@ class UserRepositoryTest {
     userRepository.save(user2);
 
     User localResult = userRepository.findByEmail(localTestEmail).orElseThrow(() -> new NotFoundException("local user를 찾을 수 없습니다."));
-    User oauthResult = userRepository.findByEmail(oauthTestEmail).orElseThrow(() -> new NotFoundException("local user를 찾을 수 없습니다."));
+    User oauthResult = userRepository.findByEmail(oauthTestEmail).orElseThrow(() -> new NotFoundException("oauth user를 찾을 수 없습니다."));
 
     assertThat(localResult).isInstanceOf(LocalUser.class);
     assertThat(oauthResult).isInstanceOf(OAuthUser.class);
+    assertThat(localResult.getNickname()).isEqualTo("local유저");
+    assertThat(oauthResult.getNickname()).isEqualTo("oauth유저");
   }
 }

--- a/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
@@ -9,12 +9,14 @@ import com.prgrms.coretime.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.*;
 
-@SpringBootTest
+@DataJpaTest
 @ActiveProfiles({"test"})
 class UserRepositoryTest {
 
@@ -27,7 +29,7 @@ class UserRepositoryTest {
   @Test
   @DisplayName("UserRepository를 통해 LocalUser와 OAuthUser instance를 가져올 수 있다.")
   void testFindByEmail() throws Throwable {
-    School testSchool = new School(1L, "아주대학교", "ajou.ac.kr");
+    School testSchool = new School("아주대학교", "ajou.ac.kr");
     String localTestEmail = "local@ajou.ac.kr";
     String oauthTestEmail = "oauth@ajou.ac.kr";
     User user1 = LocalUser.builder()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,8 +3,11 @@ spring:
     host: redis_dev
     port: 6379
     password:
+  h2:
+    console:
+      enabled: true
   datasource:
-    url: jdbc:h2:tcp://localhost/~/coretime
+    url: "jdbc:h2:mem:coretime;MODE=MYSQL;DB_CLOSE_DELAY=-1"
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
1. JWT 로컬 로그인 시, access token을 발급한다.
 * token payload: userId, nickname, email, schoolId, roles
 * 일단 다 집어넣어 놨습니다. roles에는 "USER"라는 디폴트값만 넣었습니다.
 * JwtPrincipal의 필드값을 public final로 선언했습니다. 강의를 따라서 했는데, final로 선언되었기 때문에 public이어도 크게 문제가 될 것 같지는 않다고 생각해서 그대로 작성했습니다.
2. @AuthenticationPrincipal annotation을 활용하여 로그인한 사용자 확인하는 test api 구현함

### 로그인한 사용자 확인하는 법
* api 요청 시, header에 accessToken, value에 token을 넣습니다.
![image](https://user-images.githubusercontent.com/52846807/176141289-7263eafb-ee01-4cd6-a94b-fe9cd502aa8f.png)
* 본인이 작성한 api에 @AuthenticationPrincipal JwtPrincipal principal을 추가합니다.
```java
public ResponseEntity<ApiResponse<JwtPrincipal>> getPrincipalInfo(@AuthenticationPrincipal JwtPrincipal principal) {
    /*
    * principal.email
    * principal.schoolId
    * principal.userId
    * principal.nickname
    * principal.token
    * 등등을 그대로 사용하거나 자신이 필요한 값은 db에서 조회해서 나온 entity의 필드를 사용하시면 될 것 같습니다.
    * /
    return ResponseEntity.ok(new ApiResponse<>("현재 로그인한 사용자입니다.", principal));
  }
```
