### PR TITLE
✅ feat : TimetableService에 친구 기본 시간표 목록과 친구 기본 시간표 메서드 구현

### DIFF
--- a/src/main/java/com/prgrms/coretime/timetable/domain/Semester.java
+++ b/src/main/java/com/prgrms/coretime/timetable/domain/Semester.java
@@ -1,5 +1,14 @@
 package com.prgrms.coretime.timetable.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Semester {
-  FIRST, SECOND, SUMMER, WINTER
+  FIRST(0), SUMMER(1), SECOND(2), WINTER(3);
+
+  private int order;
+
+  Semester(int order) {
+    this.order = order;
+  }
 }

--- a/src/main/java/com/prgrms/coretime/timetable/domain/repository/timetable/TimetableCustomRepository.java
+++ b/src/main/java/com/prgrms/coretime/timetable/domain/repository/timetable/TimetableCustomRepository.java
@@ -14,6 +14,8 @@ public interface TimetableCustomRepository {
 
   Optional<Timetable> getRecentlyAddedTimetable(Long userId, Integer year, Semester semester);
 
+  List<Timetable> getDefaultTimetables(Long userId);
+
   List<Timetable> getTimetables(Long userId, Integer year, Semester semester);
 
   boolean isFirstTimetable(Long userId, Integer year, Semester semester);

--- a/src/main/java/com/prgrms/coretime/timetable/domain/repository/timetable/TimetableRepositoryImpl.java
+++ b/src/main/java/com/prgrms/coretime/timetable/domain/repository/timetable/TimetableRepositoryImpl.java
@@ -66,6 +66,16 @@ public class TimetableRepositoryImpl implements TimetableCustomRepository {
   }
 
   @Override
+  public List<Timetable> getDefaultTimetables(Long userId) {
+    return  queryFactory
+        .selectFrom(timetable)
+        .where(
+            getDefaultTimetablesCondition(userId)
+        )
+        .fetch();
+  }
+
+  @Override
   public List<Timetable> getTimetables(Long userId, Integer year, Semester semester) {
     return queryFactory
         .selectFrom(timetable)
@@ -109,15 +119,16 @@ public class TimetableRepositoryImpl implements TimetableCustomRepository {
     return sameNameTableCondition;
   }
 
-  private BooleanBuilder getIdYearSemesterCondition(Long userId, Integer year, Semester semester) {
-    BooleanBuilder idYearSemesterCondition = new BooleanBuilder();
+  private BooleanBuilder getDefaultTimetableCondition(Long userId, Integer year, Semester semester) {
+    BooleanBuilder defaultTableCondition = new BooleanBuilder();
 
-    idYearSemesterCondition
+    defaultTableCondition
         .and(userIdEq(userId))
         .and(yearEq(year))
-        .and(semesterEq(semester));
+        .and(semesterEq(semester))
+        .and(timetable.isDefault.eq(true));
 
-    return idYearSemesterCondition;
+    return defaultTableCondition;
   }
 
   private BooleanBuilder getTimetableCondition(Long userId, Long timetableId) {
@@ -130,16 +141,25 @@ public class TimetableRepositoryImpl implements TimetableCustomRepository {
     return timetableCondition;
   }
 
-  private BooleanBuilder getDefaultTimetableCondition(Long userId, Integer year, Semester semester) {
-    BooleanBuilder defaultTableCondition = new BooleanBuilder();
+  private BooleanBuilder getDefaultTimetablesCondition(Long userId) {
+    BooleanBuilder defaultTimetablesCondition = new BooleanBuilder();
 
-    defaultTableCondition
+    defaultTimetablesCondition
         .and(userIdEq(userId))
-        .and(yearEq(year))
-        .and(semesterEq(semester))
         .and(timetable.isDefault.eq(true));
 
-    return defaultTableCondition;
+    return defaultTimetablesCondition;
+  }
+
+  private BooleanBuilder getIdYearSemesterCondition(Long userId, Integer year, Semester semester) {
+    BooleanBuilder idYearSemesterCondition = new BooleanBuilder();
+
+    idYearSemesterCondition
+        .and(userIdEq(userId))
+        .and(yearEq(year))
+        .and(semesterEq(semester));
+
+    return idYearSemesterCondition;
   }
 
   private BooleanBuilder getCountOfTableCondition(Long userId, Integer year, Semester semester) {

--- a/src/main/java/com/prgrms/coretime/timetable/dto/response/FriendDefaultTimetableInfo.java
+++ b/src/main/java/com/prgrms/coretime/timetable/dto/response/FriendDefaultTimetableInfo.java
@@ -1,0 +1,17 @@
+package com.prgrms.coretime.timetable.dto.response;
+
+import com.prgrms.coretime.timetable.domain.Semester;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FriendDefaultTimetableInfo {
+  private int year;
+  private Semester semester;
+
+  public FriendDefaultTimetableInfo(int year, Semester semester) {
+    this.year = year;
+    this.semester = semester;
+  }
+}

--- a/src/main/java/com/prgrms/coretime/timetable/service/TimetableService.java
+++ b/src/main/java/com/prgrms/coretime/timetable/service/TimetableService.java
@@ -6,6 +6,7 @@ import static com.prgrms.coretime.timetable.domain.repository.enrollment.Lecture
 import static com.prgrms.coretime.timetable.domain.repository.enrollment.LectureType.CUSTOM;
 
 import com.prgrms.coretime.common.error.exception.NotFoundException;
+import com.prgrms.coretime.friend.domain.FriendRepository;
 import com.prgrms.coretime.timetable.domain.Semester;
 import com.prgrms.coretime.timetable.domain.lecture.Lecture;
 import com.prgrms.coretime.timetable.domain.repository.enrollment.EnrollmentRepository;
@@ -15,6 +16,7 @@ import com.prgrms.coretime.timetable.domain.repository.timetable.TimetableReposi
 import com.prgrms.coretime.timetable.domain.timetable.Timetable;
 import com.prgrms.coretime.timetable.dto.request.TimetableCreateRequest;
 import com.prgrms.coretime.timetable.dto.request.TimetableUpdateRequest;
+import com.prgrms.coretime.timetable.dto.response.FriendDefaultTimetableInfo;
 import com.prgrms.coretime.timetable.dto.response.LectureDetailInfo;
 import com.prgrms.coretime.timetable.dto.response.LectureInfo;
 import com.prgrms.coretime.timetable.dto.response.TimetableInfo;
@@ -40,6 +42,7 @@ public class TimetableService {
   private final LectureDetailRepository lectureDetailRepository;
   private final LectureRepository lectureRepository;
   private final UserRepository userRepository;
+  private final FriendRepository friendRepository;
 
   @Transactional
   public Long createTimetable(@RequestBody @Valid TimetableCreateRequest timetableCreateRequest) {
@@ -85,8 +88,8 @@ public class TimetableService {
     // TODO : 사용자 ID 가져오는 로직이 필요하다.
 
     Long userId = 1L;
-    Timetable defaultTimetable = timetableRepository.getDefaultTimetable(userId, year, semester).orElseThrow(() -> new NotFoundException(NOT_FOUND));
-    List<LectureInfo> enrollmentedLectures = getEnrollmentedLecturesByTimetableId(defaultTimetable.getId());
+    Timetable defaultTimetable = getDefaultTimetable(userId, year, semester);
+    List<LectureInfo> enrollmentedLectures = getEnrollmentedLectures(defaultTimetable.getId());
 
     return TimetableResponse.builder()
         .timetableId(defaultTimetable.getId())
@@ -104,7 +107,7 @@ public class TimetableService {
 
     Long userId = 1L;
     Timetable timetable = getTimetableOfUser(userId, timetableId);
-    List<LectureInfo> enrollmentedLectures = getEnrollmentedLecturesByTimetableId(timetableId);
+    List<LectureInfo> enrollmentedLectures = getEnrollmentedLectures(timetableId);
 
     return TimetableResponse.builder()
         .timetableId(timetable.getId())
@@ -116,9 +119,25 @@ public class TimetableService {
         .build();
   }
 
-  // TODO : 친구 시간표 조회
-  // (userId = 사용자의 ID) or (userId != 사용자의 ID and userId와 사용자의 Id 친구)
-  // 친구의 default 시간표를 조회 해야한다.
+  @Transactional
+  public List<FriendDefaultTimetableInfo> getFriendDefaultTimetableInfos(Long userId, Long friendId) {
+    validateFriendRelationship(userId, friendId);
+
+    return timetableRepository.getDefaultTimetables(
+            friendId).stream()
+        .map(timetable -> new FriendDefaultTimetableInfo(timetable.getYear(), timetable.getSemester()))
+        .sorted((o1, o2) -> compare(o1, o2))
+        .toList();
+  }
+
+  @Transactional
+  public List<LectureInfo> getDefaultTimetableOfFriend(Long userId, Long friendId, int year, Semester semester) {
+    validateFriendRelationship(userId, friendId);
+
+    Timetable friendDefaultTimetable = getDefaultTimetable(userId, year, semester);
+
+    return getEnrollmentedLectures(friendDefaultTimetable.getId());
+  }
 
   @Transactional
   public void updateTimetable(Long timetableId, TimetableUpdateRequest timetableUpdateRequest) {
@@ -139,10 +158,7 @@ public class TimetableService {
     timetable.updateName(updatedTimetableName.trim());
 
     if(updatedIsDefault) {
-      Timetable preDefaultTimetable = timetableRepository
-          .getDefaultTimetable(userId, timetable.getYear(), timetable.getSemester())
-          .orElseThrow(() -> new NotFoundException(NOT_FOUND));
-
+      Timetable preDefaultTimetable = getDefaultTimetable(userId, timetable.getYear(), timetable.getSemester());
       preDefaultTimetable.makeNonDefault();
       timetable.makeDefault();
     }
@@ -170,11 +186,21 @@ public class TimetableService {
     }
   }
 
+  private Timetable getDefaultTimetable(Long userId, Integer year, Semester semester) {
+    return timetableRepository.getDefaultTimetable(userId, year, semester).orElseThrow(() -> new NotFoundException(NOT_FOUND));
+  }
+
   private Timetable getTimetableOfUser(Long userId, Long timetableId) {
     return timetableRepository.getTimetableByUserIdAndTimetableId(userId, timetableId).orElseThrow(() -> new NotFoundException(NOT_FOUND));
   }
 
-  private List<LectureInfo> getEnrollmentedLecturesByTimetableId(Long timetableId) {
+  private void validateFriendRelationship(Long userId, Long friendId) {
+    if(!friendRepository.existsFriendRelationship(userId, friendId)) {
+      throw new IllegalArgumentException("친구 관계가 아닙니다.");
+    }
+  }
+
+  private List<LectureInfo> getEnrollmentedLectures(Long timetableId) {
     return enrollmentRepository.getEnrollmentsWithLectureByTimetableId(timetableId, ALL).stream()
         .map(enrollment -> {
           Lecture lecture = enrollment.getLecture();
@@ -198,5 +224,13 @@ public class TimetableService {
               .build();
         })
         .collect(Collectors.toList());
+  }
+
+  private int compare(FriendDefaultTimetableInfo o1, FriendDefaultTimetableInfo o2) {
+    if (o1.getYear() == o2.getYear()) {
+      return o2.getSemester().getOrder() - o1.getSemester().getOrder() ;
+    } else {
+      return o2.getYear() - o1.getYear();
+    }
   }
 }

--- a/src/test/java/com/prgrms/coretime/timetable/service/TimetableServiceTest.java
+++ b/src/test/java/com/prgrms/coretime/timetable/service/TimetableServiceTest.java
@@ -1,20 +1,29 @@
 package com.prgrms.coretime.timetable.service;
 
 import static com.prgrms.coretime.common.ErrorCode.NOT_FOUND;
+import static com.prgrms.coretime.timetable.domain.Semester.FIRST;
 import static com.prgrms.coretime.timetable.domain.Semester.SECOND;
+import static com.prgrms.coretime.timetable.domain.Semester.SUMMER;
+import static com.prgrms.coretime.timetable.domain.Semester.WINTER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.prgrms.coretime.common.error.exception.NotFoundException;
+import com.prgrms.coretime.friend.domain.FriendRepository;
 import com.prgrms.coretime.school.domain.School;
+import com.prgrms.coretime.timetable.domain.Semester;
 import com.prgrms.coretime.timetable.domain.repository.timetable.TimetableRepository;
 import com.prgrms.coretime.timetable.domain.timetable.Timetable;
 import com.prgrms.coretime.timetable.dto.request.TimetableCreateRequest;
+import com.prgrms.coretime.timetable.dto.response.FriendDefaultTimetableInfo;
 import com.prgrms.coretime.user.domain.LocalUser;
 import com.prgrms.coretime.user.domain.User;
 import com.prgrms.coretime.user.domain.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,12 +35,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TimetableServiceTest {
-
   @Mock
   private TimetableRepository timetableRepository;
-
   @Mock
   private UserRepository userRepository;
+  @Mock
+  private FriendRepository friendRepository;
 
   @InjectMocks
   private TimetableService timetableService;
@@ -51,7 +60,7 @@ class TimetableServiceTest {
       .year(2022)
       .semester(SECOND)
       .user(user)
-      .isDefault(false)
+      .isDefault(true)
       .build();
 
 
@@ -93,6 +102,61 @@ class TimetableServiceTest {
       timetableService.createTimetable(timetableCreateRequest);
 
       verify(timetableRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("DefaultTimetableInfo들이 연도와 학기 내림차순으로 잘 정렬되는지 확인하는 테스트")
+    void testSortingOfDefaultTimetableInfos() {
+      List<Timetable> timetables = new ArrayList<>();
+
+      for(Semester semester : Semester.values()) {
+        timetables.add(Timetable.builder()
+            .name("시간표"+semester.getOrder())
+            .year(2022)
+            .semester(semester)
+            .user(user)
+            .isDefault(true)
+            .build());
+
+        timetables.add(Timetable.builder()
+            .name("시간표"+semester.getOrder())
+            .year(2021)
+            .semester(semester)
+            .user(user)
+            .isDefault(true)
+            .build());
+      }
+
+      Long userId = 1L;
+      Long friendId = 2L;
+      when(friendRepository.existsFriendRelationship(userId, friendId)).thenReturn(true);
+      when(timetableRepository.getDefaultTimetables(friendId)).thenReturn(timetables);
+
+      List<FriendDefaultTimetableInfo> friendDefaultTimetableInfos = timetableService.getFriendDefaultTimetableInfos(userId, friendId);
+
+      assertThat(friendDefaultTimetableInfos.get(0).getYear()).isEqualTo(2022);
+      assertThat(friendDefaultTimetableInfos.get(0).getSemester()).isEqualTo(WINTER);
+
+      assertThat(friendDefaultTimetableInfos.get(1).getYear()).isEqualTo(2022);
+      assertThat(friendDefaultTimetableInfos.get(1).getSemester()).isEqualTo(SECOND);
+
+      assertThat(friendDefaultTimetableInfos.get(2).getYear()).isEqualTo(2022);
+      assertThat(friendDefaultTimetableInfos.get(2).getSemester()).isEqualTo(SUMMER);
+
+      assertThat(friendDefaultTimetableInfos.get(3).getYear()).isEqualTo(2022);
+      assertThat(friendDefaultTimetableInfos.get(3).getSemester()).isEqualTo(FIRST);
+
+      assertThat(friendDefaultTimetableInfos.get(4).getYear()).isEqualTo(2021);
+      assertThat(friendDefaultTimetableInfos.get(4).getSemester()).isEqualTo(WINTER);
+
+      assertThat(friendDefaultTimetableInfos.get(5).getYear()).isEqualTo(2021);
+      assertThat(friendDefaultTimetableInfos.get(5).getSemester()).isEqualTo(SECOND);
+
+      assertThat(friendDefaultTimetableInfos.get(6).getYear()).isEqualTo(2021);
+      assertThat(friendDefaultTimetableInfos.get(6).getSemester()).isEqualTo(SUMMER);
+
+      assertThat(friendDefaultTimetableInfos.get(7).getYear()).isEqualTo(2021);
+      assertThat(friendDefaultTimetableInfos.get(7).getSemester()).isEqualTo(FIRST);
     }
   }
 }


### PR DESCRIPTION
## 👩‍💻 구현 내용
TimetableService에 친구 기본 시간표 목록과 친구 기본 시간표 메서드 구현

* 친구 기본 시간표 목록 반환
  * ```getFriendDefaultTimetableInfos(Long userId, Long friendId) { ... }```
  * 친구가 가지고 있는 기본 시간표의 연도와 학기들을 반환합니다.
  * 사용예시
  <img width="340" alt="스크린샷 2022-07-02 오후 6 03 53" src="https://user-images.githubusercontent.com/41898085/176994070-5253109d-142b-41ba-8db7-cb36e1285c59.png">

* 친구 기본 시간표 반환
  * ```getDefaultTimetableOfFriend(Long userId, Long friendId, int year, Semester semester) { ... }```
  * 기본 시간표에 등록된 강의들을 반환 합니다.

