### PR TITLE
Lmhj 87 댓글 생성시 유저와 익명번호 매칭

### DIFF
--- a/src/main/java/com/prgrms/coretime/comment/controller/CommentController.java
+++ b/src/main/java/com/prgrms/coretime/comment/controller/CommentController.java
@@ -4,10 +4,12 @@ import com.prgrms.coretime.comment.dto.request.CommentCreateRequest;
 import com.prgrms.coretime.comment.dto.response.CommentCreateResponse;
 import com.prgrms.coretime.comment.service.CommentService;
 import com.prgrms.coretime.common.ApiResponse;
+import com.prgrms.coretime.common.jwt.JwtPrincipal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,17 +29,20 @@ public class CommentController {
    */
   @PostMapping()
   public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
-      // 현재 로그인한 User 필요
+      @AuthenticationPrincipal JwtPrincipal principal,
       @RequestBody CommentCreateRequest commentCreateRequest) throws URISyntaxException {
 
-    CommentCreateResponse data = commentService.createComment(commentCreateRequest);
+    CommentCreateResponse data = commentService.createComment(principal.userId,
+        commentCreateRequest);
     URI location = new URI("/api/v1/posts/" + commentCreateRequest.getPostId());
     return ResponseEntity.created(location).body(new ApiResponse("댓글 생성 성공", data));
   }
 
   @DeleteMapping("/{commentId}")
-  public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId) {
-    commentService.deleteComment(commentId);
+  public ResponseEntity<ApiResponse<Void>> deleteComment(
+      @AuthenticationPrincipal JwtPrincipal principal,
+      @PathVariable Long commentId) {
+    commentService.deleteComment(principal.userId, commentId);
     return ResponseEntity.ok(new ApiResponse("댓글 삭제 성공"));
   }
 

--- a/src/main/java/com/prgrms/coretime/comment/controller/CommentLikeController.java
+++ b/src/main/java/com/prgrms/coretime/comment/controller/CommentLikeController.java
@@ -2,10 +2,12 @@ package com.prgrms.coretime.comment.controller;
 
 import com.prgrms.coretime.comment.service.CommentLikeService;
 import com.prgrms.coretime.common.ApiResponse;
+import com.prgrms.coretime.common.jwt.JwtPrincipal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,19 +22,21 @@ public class CommentLikeController {
   private final CommentLikeService commentLikeService;
 
   @PostMapping("/{commentId}/like")
-  public ResponseEntity<ApiResponse<Void>> createLike(Long userId,
+  public ResponseEntity<ApiResponse<Void>> createLike(
+      @AuthenticationPrincipal JwtPrincipal principal,
       @PathVariable Long commentId
   )
       throws URISyntaxException {
-    commentLikeService.createLike(userId, commentId);
+    commentLikeService.createLike(principal.userId, commentId);
     URI location = new URI("/api/v1/comments");
     return ResponseEntity.created(location).body(new ApiResponse("댓글 좋아요 생성"));
   }
 
   @DeleteMapping("/{commentId}/like")
-  public ResponseEntity<ApiResponse<Void>> deleteLike(Long userId, @PathVariable Long commentId)
+  public ResponseEntity<ApiResponse<Void>> deleteLike(
+      @AuthenticationPrincipal JwtPrincipal principal, @PathVariable Long commentId)
       throws URISyntaxException {
-    commentLikeService.deleteLike(userId, commentId);
+    commentLikeService.deleteLike(principal.userId, commentId);
     URI location = new URI("/api/v1/comments");
     return ResponseEntity.created(location).body(new ApiResponse<>("댓글 삭제 생성"));
   }

--- a/src/main/java/com/prgrms/coretime/comment/domain/Comment.java
+++ b/src/main/java/com/prgrms/coretime/comment/domain/Comment.java
@@ -68,7 +68,8 @@ public class Comment extends BaseEntity {
 
   //TODO: 생성자 처리 어떻게 할 건지, RequestDto 말고 여기서 Dto 받아서 생성할 건지 고민
   @Builder
-  public Comment(User user, Post post, Comment parent, Boolean isAnonymous, String content) {
+  public Comment(User user, Post post, Comment parent, Boolean isAnonymous, Integer anonymousSeq,
+      String content) {
     validatePost(post);
     validateUser(user);
     validateIsAnonymous(isAnonymous);
@@ -78,9 +79,7 @@ public class Comment extends BaseEntity {
     this.user = user; // 단방향
     setParent(parent); // 양방향
     this.isAnonymous = isAnonymous;
-    if (this.isAnonymous) {
-      setAnonymousSeq(this.post.getAnonymousSeqAndAdd());
-    }
+    this.anonymousSeq = anonymousSeq;
     this.isDelete = false;
     this.content = content;
   }

--- a/src/main/java/com/prgrms/coretime/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/prgrms/coretime/comment/domain/repository/CommentRepository.java
@@ -1,8 +1,12 @@
 package com.prgrms.coretime.comment.domain.repository;
 
 import com.prgrms.coretime.comment.domain.Comment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  @Query("select c from Comment c where c.user.id = :userId and c.post.id = :postId and c.isAnonymous = true")
+  Optional<Comment> findFirstByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/prgrms/coretime/comment/service/CommentLikeService.java
+++ b/src/main/java/com/prgrms/coretime/comment/service/CommentLikeService.java
@@ -5,6 +5,10 @@ import com.prgrms.coretime.comment.domain.CommentLike;
 import com.prgrms.coretime.comment.domain.CommentLikeId;
 import com.prgrms.coretime.comment.domain.repository.CommentLikeRepository;
 import com.prgrms.coretime.comment.domain.repository.CommentRepository;
+import com.prgrms.coretime.common.ErrorCode;
+import com.prgrms.coretime.common.error.exception.NotFoundException;
+import com.prgrms.coretime.user.domain.User;
+import com.prgrms.coretime.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,46 +22,46 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentLikeService {
 
+  private final UserRepository userRepository;
   private final CommentRepository commentRepository;
   private final CommentLikeRepository commentLikeRepository;
 
   public void createLike(Long userId, Long commentId) {
     CommentLikeId commentLikeId = new CommentLikeId(userId, commentId);
     if (isPresentLike(commentLikeId)) {
-      throw new IllegalArgumentException("해당 좋아요가 이미 존재합니다.");
+      throw new IllegalArgumentException(ErrorCode.COMMENT_LIKE_ALREADY_EXISTS.getMessage());
     }
+    User currentUser = getCurrentUser(userId);
     Comment comment = getComment(commentId);
 
-    /*
-     * TODO : 저장 로직 안넣음
-     *  추후 통합테스트 시 user 넣기
-     * */
+    commentLikeRepository.save(new CommentLike(currentUser, comment));
   }
 
-  // 좋아요 삭제는 무조건 현재 유저만이 해당 좋아요를 삭제할 수 있다.
   public void deleteLike(Long userId, Long commentId) {
     CommentLikeId commentLikeId = new CommentLikeId(userId, commentId);
     if (!isPresentLike(commentLikeId)) {
-      throw new IllegalArgumentException("해당 좋아요가 존재하지 않습니다.");
+      throw new IllegalArgumentException(ErrorCode.COMMENT_LIKE_NOT_FOUND.getMessage());
     }
     commentLikeRepository.deleteById(commentLikeId);
   }
 
   private Comment getComment(Long commentId) {
     return commentRepository.findById(commentId)
-        .orElseThrow(() -> new IllegalArgumentException("현재 댓글이 존재하지 않습니다."));
+        .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
   }
 
   private CommentLike getCommentLike(Long userId, Long commentId) {
     return commentLikeRepository.findById(new CommentLikeId(userId, commentId))
-        .orElseThrow(() -> new IllegalArgumentException("해당 좋아요가 존재하지 않습니다."));
+        .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
   }
 
   private boolean isPresentLike(CommentLikeId commentLikeId) {
-    /**
-     * TODO : 일단 exists 쓰고, 추후 limit로 리팩터 하자 (참고 : jpql은 limit 지원 안해)
-     * */
     return commentLikeRepository.existsById(commentLikeId);
+  }
+
+  private User getCurrentUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
   }
 
 }

--- a/src/main/java/com/prgrms/coretime/comment/service/CommentService.java
+++ b/src/main/java/com/prgrms/coretime/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.prgrms.coretime.comment.service;
 
+import com.mysema.commons.lang.Assert;
 import com.prgrms.coretime.comment.domain.Comment;
 import com.prgrms.coretime.comment.domain.repository.CommentRepository;
 import com.prgrms.coretime.comment.dto.request.CommentCreateRequest;
@@ -9,6 +10,7 @@ import com.prgrms.coretime.common.error.exception.NotFoundException;
 import com.prgrms.coretime.post.domain.Post;
 import com.prgrms.coretime.post.domain.repository.PostRepository;
 import com.prgrms.coretime.user.domain.User;
+import com.prgrms.coretime.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,43 +20,63 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentService {
 
+  private final UserRepository userRepository;
   private final PostRepository postRepository;
   private final CommentRepository commentRepository;
 
-  public CommentCreateResponse createComment(CommentCreateRequest commentCreateRequest) {
-    User user = new User("example.com", "it is unsafeUser"); // 이부분이 로그인 받아온 user가 되어야함.
+  // 1. 생성할때 기존 유저가 익명 댓글을 썼는지 확인.
+  // 2. 익명댓글을 썼다면 기존 유저가 사용한 익명 번호를 가져와야함.
+  // 3. 처음 익명댓글을 쓰는 거라면 post에서 가져오기.
+  public CommentCreateResponse createComment(Long userId,
+      CommentCreateRequest commentCreateRequest) {
+    User currentUser = getCurrentUser(userId);
     Post post = getPost(commentCreateRequest.getPostId());
     Comment parent = commentCreateRequest.getParentId() == null ?
         null : getComment(commentCreateRequest.getParentId());
 
+    // 기존에 유저가 댓글을 썼다면 익명번호 가져오기
+    Integer seq = Integer.valueOf(
+        commentRepository.findFirstByUserIdAndPostId(userId, post.getId())
+            .map(comment -> comment.getAnonymousSeq())
+            .orElse(post.getAnonymousSeqAndAdd()));
+
     Comment comment = Comment.builder()
-        .user(user)
+        .user(currentUser)
         .post(post)
         .parent(parent)
         .isAnonymous(commentCreateRequest.getIsCommentAnonymous())
+        .anonymousSeq(seq)
         .content(commentCreateRequest.getContent())
         .build();
 
     commentRepository.save(comment);
 
-    return CommentCreateResponse.of(user, post, comment);
+    return CommentCreateResponse.of(currentUser, post, comment);
   }
 
-  public void deleteComment(Long commentId) {
+  public void deleteComment(Long userId, Long commentId) {
     Comment comment = getComment(commentId);
+    checkValidUser(userId, commentId);
     comment.updateDelete();
   }
 
-  /**
-   * TODO : Exception Message 관리 어떻게 할 것인지
-   */
   private Post getPost(Long postId) {
     return postRepository.findById(postId)
-        .orElseThrow(() -> new NotFoundException(ErrorCode.INVALID_INPUT_VALUE));
+        .orElseThrow(() -> new NotFoundException(ErrorCode.POST_NOT_FOUND));
   }
 
   private Comment getComment(Long commentId) {
     return commentRepository.findById(commentId)
-        .orElseThrow(() -> new NotFoundException(ErrorCode.INVALID_INPUT_VALUE));
+        .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
   }
+
+  private User getCurrentUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+  }
+
+  private void checkValidUser(Long currentUserId, Long targetUserId) {
+    Assert.isFalse(currentUserId == targetUserId, ErrorCode.BAD_REQUEST.getMessage());
+  }
+
 }

--- a/src/main/java/com/prgrms/coretime/comment/service/CommentService.java
+++ b/src/main/java/com/prgrms/coretime/comment/service/CommentService.java
@@ -35,10 +35,10 @@ public class CommentService {
         null : getComment(commentCreateRequest.getParentId());
 
     // 기존에 유저가 댓글을 썼다면 익명번호 가져오기
-    Integer seq = Integer.valueOf(
+    Integer seq = commentCreateRequest.getIsCommentAnonymous() ? Integer.valueOf(
         commentRepository.findFirstByUserIdAndPostId(userId, post.getId())
             .map(comment -> comment.getAnonymousSeq())
-            .orElse(post.getAnonymousSeqAndAdd()));
+            .orElse(post.getAnonymousSeqAndAdd())) : null;
 
     Comment comment = Comment.builder()
         .user(currentUser)

--- a/src/main/java/com/prgrms/coretime/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
   INVALID_TYPE_VALUE(400, "C002", "요청 값의 타입이 잘못되었습니다."),
   INVALID_INPUT_VALUE(400, "C003", "적절하지 않은 값입니다."),
   NOT_FOUND(404, "C004", "해당 리소스를 찾을 수 없습니다."),
+  BAD_REQUEST(400, "C005", "잘못된 요청입니다."),
   MISSING_REQUEST_PARAMETER(400, "C005", "필수 파라미터가 누락되었습니다."),
   INVALID_LENGTH(400, "C006", "올바르지 않은 길이입니다."),
   USER_NOT_FOUND(500, "U001", "유저가 존재하지 않습니다."),
@@ -36,15 +37,19 @@ public enum ErrorCode {
   FRIEND_ALREADY_EXISTS(400, "F003", "이미 등록된 친구입니다."),
   FRIEND_NOT_FOUND(404, "F004", "해당 friend 리소스를 찾을 수 없습니다."),
 
-
   /**
-   *  Post Domain
-   * */
+   * Post Domain
+   */
   POST_NOT_FOUND(400, "P001", "해당 Post 리소스를 찾을 수 없습니다."),
   BOARD_NOT_FOUND(400, "B001", "해당 Board 리소스를 찾을 수 없습니다."),
   PHOTO_NOT_FOUND(400, "PH001", "해당 Photo 리소스를 찾을 수 없습니다."),
   POST_LIKE_NOT_FOUND(400, "PL001", "해당 User 와 Post 의 좋아요가 존재하지 않습니다."),
-  POST_LIKE_ALREADY_EXISTS(400, "PL002", "해당 User 와 Post 의 좋아요가 이미 존재합니다.");
+  POST_LIKE_ALREADY_EXISTS(400, "PL002", "해당 User 와 Post 의 좋아요가 이미 존재합니다."),
+
+  /**
+   * Comment Domain
+   **/
+  COMMENT_NOT_FOUND(400, "COM001", "해당 Comment를 찾을 수 없습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/prgrms/coretime/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorCode.java
@@ -49,8 +49,9 @@ public enum ErrorCode {
   /**
    * Comment Domain
    **/
-  COMMENT_NOT_FOUND(400, "COM001", "해당 Comment를 찾을 수 없습니다.");
-
+  COMMENT_NOT_FOUND(400, "COM001", "해당 Comment를 찾을 수 없습니다."),
+  COMMENT_LIKE_ALREADY_EXISTS(400, "COM002", "해당 댓글에 이미 좋아요가 존재합니다."),
+  COMMENT_LIKE_NOT_FOUND(400, "COM003", "해당 댓글에 좋아요가 존재하지 않습니다.");
   private final int status;
   private final String code;
   private final String message;

--- a/src/test/java/com/prgrms/coretime/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/coretime/comment/controller/CommentControllerTest.java
@@ -52,6 +52,8 @@ class CommentControllerTest {
   @DisplayName("댓글 삭제 API 실행 시")
   class Describe_deleteCommentApi {
 
+    Long userId = 1L;
+
     Long commentId = 1L;
 
     String deleteUrl = baseUrl + "/{commentId}";
@@ -60,7 +62,7 @@ class CommentControllerTest {
     @DisplayName("없는 댓글 아이디를 삭제 할 경우")
     public void deleteIncorrectId() throws Exception {
 
-      doThrow(new IllegalArgumentException()).when(commentService).deleteComment(commentId);
+      doThrow(new IllegalArgumentException()).when(commentService).deleteComment(userId, commentId);
 
       mockMvc.perform(
               delete(deleteUrl, commentId).contentType(MediaType.APPLICATION_JSON).with(csrf()))
@@ -79,7 +81,7 @@ class CommentControllerTest {
     @DisplayName("정상적인 댓글을 삭제할 경우")
     public void deleteCorrectId() throws Exception {
 
-      doNothing().when(commentService).deleteComment(commentId);
+      doNothing().when(commentService).deleteComment(userId, commentId);
 
       mockMvc.perform(
               delete(deleteUrl, commentId).contentType(MediaType.APPLICATION_JSON).with(csrf()))

--- a/src/test/java/com/prgrms/coretime/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/coretime/comment/controller/CommentControllerTest.java
@@ -9,7 +9,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.coretime.comment.service.CommentService;
+import com.prgrms.coretime.common.ErrorCode;
 import com.prgrms.coretime.common.config.WebSecurityConfig;
+import com.prgrms.coretime.common.error.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,8 +26,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = CommentController.class, excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class))
-@MockBean(JpaMetamodelMappingContext.class)
-@WithMockUser("USERS")
+@MockBean({JpaMetamodelMappingContext.class})
+@WithMockUser(roles = {"USER"})
 class CommentControllerTest {
 
   @Autowired
@@ -36,7 +38,7 @@ class CommentControllerTest {
 
   @MockBean
   CommentService commentService;
-
+  
   String baseUrl = "/api/v1/comments";
 
   /*
@@ -62,10 +64,11 @@ class CommentControllerTest {
     @DisplayName("없는 댓글 아이디를 삭제 할 경우")
     public void deleteIncorrectId() throws Exception {
 
-      doThrow(new IllegalArgumentException()).when(commentService).deleteComment(userId, commentId);
+      doThrow(new NotFoundException(ErrorCode.COMMENT_NOT_FOUND)).when(commentService)
+          .deleteComment(userId, commentId);
 
       mockMvc.perform(
-              delete(deleteUrl, commentId).contentType(MediaType.APPLICATION_JSON).with(csrf()))
+              delete(deleteUrl, commentId).contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/prgrms/coretime/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/prgrms/coretime/comment/controller/CommentLikeControllerTest.java
@@ -27,8 +27,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(value = CommentLikeController.class,
-    excludeFilters =
-    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class)
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class)
 )
 @MockBean(JpaMetamodelMappingContext.class)
 @WithMockUser(roles = "USER")

--- a/src/test/java/com/prgrms/coretime/comment/domain/CommentTest.java
+++ b/src/test/java/com/prgrms/coretime/comment/domain/CommentTest.java
@@ -187,6 +187,7 @@ class CommentTest {
           .post(post)
           .parent(null)
           .isAnonymous(true)
+          .anonymousSeq(post.getAnonymousSeqAndAdd())
           .content(_300BytesString)
           .build();
 
@@ -195,6 +196,7 @@ class CommentTest {
           .post(post)
           .parent(anonymousComment1)
           .isAnonymous(false)
+          .anonymousSeq(null)
           .content(_300BytesString)
           .build();
 
@@ -203,6 +205,7 @@ class CommentTest {
           .post(post)
           .parent(null)
           .isAnonymous(true)
+          .anonymousSeq(post.getAnonymousSeqAndAdd())
           .content(_300BytesString)
           .build();
 


### PR DESCRIPTION
## 구현 내용

- 댓글 생성시 익명번호 잘못들어가는 케이스 수정
  - 기존 유저의 댓글이 존재하는 것이 아니라 익명 댓글이 존재해야한다.
- principal 받는 것으로 controller 파라미터 수정 및 로직 변경
- CommentService 및 CommentLikeService에 비즈니스 로직 완성
