### PR TITLE
Blacklist 처리와 로그아웃 구현

### DIFF
--- a/src/main/java/com/prgrms/coretime/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/coretime/common/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
   INVALID_ACCOUNT_REQUEST(400, "U002", "아이디 및 비밀번호가 올바르지 않습니다."),
   INVALID_TOKEN_REQUEST(400, "U003", "토큰이 올바르지 않습니다."),
   USER_ALREADY_EXISTS(400, "U004", "유저가 이미 존재합니다."),
-
+  TOKEN_EXPIRED(400, "U005", "토큰이 만료되었습니다."),
   /**
    * Friend Domain
    */

--- a/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
@@ -14,8 +14,6 @@ public class JwtConfig {
 
   private String header;
 
-  private String refreshHeader;
-
   private String issuer;
 
   private String clientSecret;

--- a/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/JwtConfig.java
@@ -2,6 +2,7 @@ package com.prgrms.coretime.common.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -22,4 +23,7 @@ public class JwtConfig {
   private int expirySeconds;
 
   private int refreshExpirySeconds;
+
+  @Value("${jwt.blacklist.access-token}")
+  private String blackListPrefix;
 }

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -74,6 +74,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/api/v1/users/local/register", "/api/v1/users/local/login").permitAll()
         .antMatchers("/api/v1/users/oauth/register", "/api/v1/users/oauth/login").permitAll()
         .antMatchers("/api/v1/users/logout").permitAll()
+        .antMatchers("/api/v1/users/reissue").permitAll()
         .antMatchers("/api/v1/**").hasAuthority("USER")
         .and()
         .addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);

--- a/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/coretime/common/config/WebSecurityConfig.java
@@ -4,7 +4,6 @@ import com.prgrms.coretime.common.jwt.Jwt;
 import com.prgrms.coretime.common.jwt.JwtAuthenticationFilter;
 import com.prgrms.coretime.common.jwt.JwtAuthenticationProvider;
 import com.prgrms.coretime.common.util.JwtService;
-import com.prgrms.coretime.common.util.RedisService;
 import com.prgrms.coretime.user.service.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -53,8 +52,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   }
 
   public JwtAuthenticationFilter jwtAuthenticationFilter() {
-    Jwt jwt = getApplicationContext().getBean(Jwt.class);
-    return new JwtAuthenticationFilter(jwtConfig.getHeader(), jwt);
+    JwtService jwtService = this.getApplicationContext().getBean(JwtService.class);
+    return new JwtAuthenticationFilter(jwtConfig.getHeader(), jwtService);
   }
 
   @Override
@@ -74,6 +73,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/swagger*/**").permitAll()
         .antMatchers("/api/v1/users/local/register", "/api/v1/users/local/login").permitAll()
         .antMatchers("/api/v1/users/oauth/register", "/api/v1/users/oauth/login").permitAll()
+        .antMatchers("/api/v1/users/logout").permitAll()
         .antMatchers("/api/v1/**").hasAuthority("USER")
         .and()
         .addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -6,7 +6,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.prgrms.coretime.common.jwt.claim.AccessClaim;
 import com.prgrms.coretime.common.jwt.claim.Claims;
-import com.prgrms.coretime.common.jwt.claim.RefreshClaim;
 import java.util.Date;
 import lombok.Getter;
 
@@ -51,13 +50,8 @@ public final class Jwt {
     return  builder.sign(algorithm);
   }
 
-  /*TODO: Refactoring*/
-  public AccessClaim verifyAccessToken(String token) throws JWTVerificationException {
+  public AccessClaim decodeAccessToken(String token) throws JWTVerificationException {
     return new AccessClaim(jwtVerifier.verify(token));
-  }
-
-  public RefreshClaim verifyRefreshToken(String token) throws JWTVerificationException {
-    return new RefreshClaim(jwtVerifier.verify(token));
   }
 
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/Jwt.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.prgrms.coretime.common.jwt.claim.AccessClaim;
 import com.prgrms.coretime.common.jwt.claim.Claims;
+import com.prgrms.coretime.common.jwt.claim.RefreshClaim;
 import java.util.Date;
 import lombok.Getter;
 
@@ -50,8 +51,12 @@ public final class Jwt {
     return  builder.sign(algorithm);
   }
 
-  public AccessClaim decodeAccessToken(String token) throws JWTVerificationException {
+  public AccessClaim verifyAccessToken(String token) throws JWTVerificationException {
     return new AccessClaim(jwtVerifier.verify(token));
+  }
+
+  public RefreshClaim verifyRefreshToken(String token) throws JWTVerificationException {
+    return new RefreshClaim(jwtVerifier.verify(token));
   }
 
 }

--- a/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/prgrms/coretime/common/jwt/JwtAuthenticationProvider.java
@@ -1,13 +1,8 @@
 package com.prgrms.coretime.common.jwt;
 
-import com.prgrms.coretime.common.ErrorCode;
-import com.prgrms.coretime.common.error.exception.AuthErrorException;
-import com.prgrms.coretime.common.jwt.claim.AccessClaim;
-import com.prgrms.coretime.common.jwt.claim.RefreshClaim;
 import com.prgrms.coretime.common.util.JwtService;
 import com.prgrms.coretime.user.domain.User;
 import com.prgrms.coretime.user.service.UserService;
-import java.time.Duration;
 import java.util.List;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.authentication.AuthenticationProvider;

--- a/src/main/java/com/prgrms/coretime/common/util/JwtService.java
+++ b/src/main/java/com/prgrms/coretime/common/util/JwtService.java
@@ -13,7 +13,6 @@ import java.util.Date;
 import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
 @Component
 public class JwtService {

--- a/src/main/java/com/prgrms/coretime/common/util/JwtService.java
+++ b/src/main/java/com/prgrms/coretime/common/util/JwtService.java
@@ -1,24 +1,32 @@
 package com.prgrms.coretime.common.util;
 
-import com.prgrms.coretime.common.ErrorCode;
+import static com.prgrms.coretime.common.ErrorCode.*;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.prgrms.coretime.common.config.JwtConfig;
 import com.prgrms.coretime.common.error.exception.AuthErrorException;
 import com.prgrms.coretime.common.jwt.Jwt;
 import com.prgrms.coretime.common.jwt.claim.AccessClaim;
 import com.prgrms.coretime.common.jwt.claim.RefreshClaim;
 import java.time.Duration;
+import java.util.Date;
 import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
-@Service
+@Component
 public class JwtService {
+
+  private final Jwt jwt;
 
   private final JwtConfig jwtConfig;
 
   private final RedisService redisService;
 
-  public JwtService(JwtConfig jwtConfig, RedisService redisService) {
+  public JwtService(Jwt jwt, JwtConfig jwtConfig,
+      RedisService redisService) {
+    this.jwt = jwt;
     this.jwtConfig = jwtConfig;
     this.redisService = redisService;
   }
@@ -27,14 +35,10 @@ public class JwtService {
     String[] roles = authorities.stream()
         .map(GrantedAuthority::getAuthority)
         .toArray(String[]::new);
-    Jwt jwt = new Jwt(jwtConfig.getIssuer(), jwtConfig.getClientSecret(),
-        jwtConfig.getExpirySeconds());
     return jwt.sign(new AccessClaim(userId, schoolId, nickname, email, roles));
   }
 
   public String createRefreshToken(String email) {
-    Jwt jwt = new Jwt(jwtConfig.getIssuer(), jwtConfig.getClientSecret(),
-        jwtConfig.getRefreshExpirySeconds());
     String refreshToken = jwt.sign(new RefreshClaim(email));
     redisService.setValues(email, refreshToken, Duration.ofMillis(
         jwtConfig.getRefreshExpirySeconds()));
@@ -44,7 +48,20 @@ public class JwtService {
   public void checkRefreshToken(String email, String refreshToken) {
     String redisToken = redisService.getValues(email);
     if(!redisToken.equals(refreshToken)) {
-      throw new AuthErrorException(ErrorCode.INVALID_TOKEN_REQUEST);
+      throw new AuthErrorException(INVALID_TOKEN_REQUEST);
     }
+  }
+
+  public void logout(String token) {
+    AccessClaim claim = jwt.decodeAccessToken(token);
+    long expiredAccessTokenTime = claim.getExp().getTime() - new Date().getTime();
+    redisService.setValues(jwtConfig.getBlackListPrefix() + token, claim.getEmail(), Duration.ofMillis(expiredAccessTokenTime));
+    redisService.deleteValues(claim.getEmail());
+  }
+
+  public AccessClaim verifyAccessToken(String token) throws JWTVerificationException {
+    String expiredAt = redisService.getValues(jwtConfig.getBlackListPrefix() + token);
+    if (expiredAt != null) throw new AuthErrorException(TOKEN_EXPIRED);
+    return jwt.decodeAccessToken(token);
   }
 }

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -99,6 +99,7 @@ public class UserController {
     return ResponseEntity.ok(new ApiResponse<>("중복검사가 완료되었습니다.", response));
   }
 
+  /*TOOD: entity 밖으로 나와도 되는지 고민*/
   @PatchMapping("/password/change")
   public ResponseEntity<ApiResponse<Object>> changePassword(@AuthenticationPrincipal JwtPrincipal principal, @RequestBody @Valid UserPasswordChangeRequest request) {
     LocalUser user = (LocalUser) userService.findByEmail(principal.email);

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -64,18 +64,6 @@ public class UserController {
     return null;
   }
 
-  @GetMapping("/principal")
-  public ResponseEntity<ApiResponse<JwtPrincipal>> getPrincipalInfo(@AuthenticationPrincipal JwtPrincipal principal) {
-    /*
-    * principal.email
-    * principal.schoolId
-    * principal.userId
-    * principal.nickname
-    * principal.token
-    * */
-    return ResponseEntity.ok(new ApiResponse<>("현재 로그인한 사용자입니다.", principal));
-  }
-
   /* TODO: 블랙아웃 처리 */
   @GetMapping("/reissue")
   public ResponseEntity<ApiResponse<LoginResponse>> reIssueAccessToken(@RequestParam("email") String email, @RequestParam("refreshToken") String refreshToken) {
@@ -102,15 +90,13 @@ public class UserController {
   /*TOOD: entity 밖으로 나와도 되는지 고민*/
   @PatchMapping("/password/change")
   public ResponseEntity<ApiResponse<Object>> changePassword(@AuthenticationPrincipal JwtPrincipal principal, @RequestBody @Valid UserPasswordChangeRequest request) {
-    LocalUser user = (LocalUser) userService.findByEmail(principal.email);
-    userService.changePassword(user, request);
+    userService.changePassword(principal.userId, request);
     return ResponseEntity.ok(new ApiResponse<>("비밀번호 변경이 완료되었습니다."));
   }
 
   @PatchMapping("/quit")
   public ResponseEntity<ApiResponse<Object>> quit(@AuthenticationPrincipal JwtPrincipal principal) {
-    User user = userService.findByEmail(principal.email);
-    userService.quit(user);
+    userService.quit(principal.userId);
     return ResponseEntity.ok(new ApiResponse<>("회원 탈퇴가 완료되었습니다."));
   }
 }

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.*;
 import com.prgrms.coretime.common.ApiResponse;
 import com.prgrms.coretime.common.jwt.JwtAuthenticationToken;
 import com.prgrms.coretime.common.jwt.JwtPrincipal;
+import com.prgrms.coretime.common.jwt.claim.AccessClaim;
 import com.prgrms.coretime.common.util.JwtService;
 import com.prgrms.coretime.user.domain.LocalUser;
 import com.prgrms.coretime.user.domain.User;
@@ -62,6 +63,12 @@ public class UserController {
   @PostMapping("/oauth/login")
   public ResponseEntity<ApiResponse<LoginResponse>> oauthLogin(@RequestBody UserLocalLoginRequest request) {
     return null;
+  }
+
+  @GetMapping("/logout")
+  public ResponseEntity<ApiResponse<Object>> logout(@RequestParam("accessToken") String accessToken) {
+    jwtService.logout(accessToken);
+    return ResponseEntity.ok(new ApiResponse<>("로그아웃이 완료되었습니다."));
   }
 
   /* TODO: 블랙아웃 처리 */

--- a/src/main/java/com/prgrms/coretime/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/coretime/user/controller/UserController.java
@@ -71,7 +71,6 @@ public class UserController {
     return ResponseEntity.ok(new ApiResponse<>("로그아웃이 완료되었습니다."));
   }
 
-  /* TODO: 블랙아웃 처리 */
   @GetMapping("/reissue")
   public ResponseEntity<ApiResponse<LoginResponse>> reIssueAccessToken(@RequestParam("email") String email, @RequestParam("refreshToken") String refreshToken) {
     User user = userService.findByEmail(email);

--- a/src/main/java/com/prgrms/coretime/user/domain/User.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/User.java
@@ -47,13 +47,13 @@ public class User extends BaseEntity {
   @JoinColumn(name = "school_id", nullable = false)
   private School school;
 
-  @Column(name = "email", unique = true, nullable = false, length = MAX_EMAIL_LENGTH)
+  @Column(name = "email", nullable = false, length = MAX_EMAIL_LENGTH)
   private String email;
 
   @Column(name = "profile_image", length = 300)
   private String profileImage;
 
-  @Column(name = "nickname", unique = true, nullable = false, length = MAX_NICKNAME_LENGTH)
+  @Column(name = "nickname", nullable = false, length = MAX_NICKNAME_LENGTH)
   private String nickname;
 
   @Column(name = "name", nullable = false, length = MAX_NAME_LENGTH)

--- a/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/coretime/user/domain/repository/UserRepository.java
@@ -7,14 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  @Query("select u from User u join fetch u.school s where u.email = :email and u.isQuit = false")
-  Optional<User> findByEmail(String email);
+  @Query("select u from User u join fetch u.school s where u.email = :email and u.isQuit = :isQuit")
+  Optional<User> findByEmailAndIsQuit(String email, Boolean isQuit);
 
-  @Query("select u from User u join fetch u.school s where u.nickname = :nickname and u.isQuit = false")
-  Optional<User> findByNickname(String nickname);
+  @Query("select u from User u join fetch u.school s where u.nickname = :nickname and u.isQuit = :isQuit")
+  Optional<User> findByNicknameAndIsQuit(String nickname, Boolean isQuit);
 
   /*TODO : isQuit = false인 것으로 체크해야 함.*/
-  boolean existsByEmail(String email);
+  boolean existsByEmailAndIsQuit(String email, Boolean isQuit);
 
-  boolean existsByNickname(String nickname);
+  boolean existsByNicknameAndIsQuit(String nickname, Boolean isQuit);
 }

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -1,14 +1,11 @@
 
 package com.prgrms.coretime.user.service;
 
-import com.prgrms.coretime.comment.domain.repository.CommentRepository;
 import com.prgrms.coretime.common.error.exception.AlreadyExistsException;
 import com.prgrms.coretime.common.error.exception.AuthErrorException;
 import com.prgrms.coretime.common.error.exception.NotFoundException;
-import com.prgrms.coretime.post.domain.repository.PostRepository;
 import com.prgrms.coretime.school.domain.School;
 import com.prgrms.coretime.school.domain.respository.SchoolRepository;
-import com.prgrms.coretime.timetable.domain.repository.timetable.TimetableRepository;
 import com.prgrms.coretime.user.domain.LocalUser;
 import com.prgrms.coretime.user.domain.User;
 import com.prgrms.coretime.user.domain.repository.UserRepository;
@@ -105,13 +102,15 @@ public class UserService {
   }
 
   @Transactional
-  public void changePassword(LocalUser user, UserPasswordChangeRequest request) {
+  public void changePassword(Long userId, UserPasswordChangeRequest request) {
+    LocalUser user = (LocalUser) findById(userId);
     user.checkPassword(passwordEncoder, request.getPassword());
     user.changePassword(passwordEncoder, request.getNewPassword());
   }
 
   @Transactional
-  public void quit(User user) {
+  public void quit(Long userId) {
+    User user = findById(userId);
     user.changeQuitFlag(true);
   }
 

--- a/src/main/java/com/prgrms/coretime/user/service/UserService.java
+++ b/src/main/java/com/prgrms/coretime/user/service/UserService.java
@@ -113,5 +113,4 @@ public class UserService {
     User user = findById(userId);
     user.changeQuitFlag(true);
   }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,8 +32,9 @@ logging:
 
 jwt:
   header: accessToken
-  refresh-header: refreshToken
   issuer: victory
   client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
   expiry-seconds: 1800
   refresh-expiry-seconds: 604800
+  blacklist:
+    access-token: BlackList_AccessToken_

--- a/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/coretime/user/domain/repository/UserRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.coretime.user.domain.repository;
 
-import com.prgrms.coretime.common.ErrorCode;
+import com.prgrms.coretime.TestConfig;
 import com.prgrms.coretime.common.error.exception.NotFoundException;
 import com.prgrms.coretime.school.domain.School;
 import com.prgrms.coretime.school.domain.respository.SchoolRepository;
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import static com.prgrms.coretime.common.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
+@Import(TestConfig.class)
 @ActiveProfiles({"test"})
 class UserRepositoryTest {
 
@@ -56,9 +56,9 @@ class UserRepositoryTest {
     userRepository.save(user1);
     userRepository.save(user2);
 
-    User localResult = userRepository.findByEmail(localTestEmail).orElseThrow(() -> new NotFoundException(
+    User localResult = userRepository.findByEmailAndIsQuit(localTestEmail, false).orElseThrow(() -> new NotFoundException(
         USER_NOT_FOUND));
-    User oauthResult = userRepository.findByEmail(oauthTestEmail).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    User oauthResult = userRepository.findByEmailAndIsQuit(oauthTestEmail, false).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
 
     assertThat(localResult).isInstanceOf(LocalUser.class);
     assertThat(oauthResult).isInstanceOf(OAuthUser.class);


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 회원 탈퇴 시, isQuit = true로 update 함. -> userRepository 사용하여 findByEmail 등으로 user를 찾은 로직이 있으신 분들은 findByEmailAndIsQuitFalse 이런 식으로 찾아주어야 함.
2. 회원 탈퇴 후, 다시 똑같은 이메일로 회원 가입 비즈니스 로직 고려
    * 일단 기존 정보는 delete 하지 않고, isQuit = false인 튜플 중에서 nickname과 email이 unique하면 insert되도록 구현함.
3. 로그아웃 api 구현
    * 기존 verifyAccessToken에서 redis에 요청한 accessToken이 없는 지 확인, 있다면 만료된 토큰이므로 토큰 만료
    * 로그아웃에서 redis에 (blacklist prefix 문자열) + accessToken을 key 값으로, email을 value로 하여 set Value, refresh Token key value는 삭제
4. 재발행 api permitAll로 권한 변경
